### PR TITLE
Various fixes

### DIFF
--- a/nbfc.py
+++ b/nbfc.py
@@ -56,6 +56,7 @@ class NbfcService:
     def stop(self):
         import signal
         os.kill(self.get_service_pid(), signal.SIGINT)
+        os.remove(self.STATE_FILE)
 
     def restart(self, readonly=False):
         try:     self.stop()
@@ -215,7 +216,7 @@ def restart(opts):
 
 def wait_for_hwmon(opts):
     HWMonNameFiles = ["/sys/class/hwmon/hwmon{}/name", "/sys/class/hwmon/hwmon{}/device/name"]
-    LinuxTempSensorNames = ["coretemp", "k10temp"]
+    LinuxTempSensorNames = ["coretemp", "k10temp", "zenpower"]
 
     for try_ in range(30):
         for name_file_fmt in HWMonNameFiles:

--- a/share/nbfc/configs/Acer Nitro AN515-43.json
+++ b/share/nbfc/configs/Acer Nitro AN515-43.json
@@ -18,87 +18,87 @@
 	 "FanDisplayName": "Ryzen 3550H",
 	 "TemperatureThresholds": [
 	  {
-	   "UpThreshold": 0,
+	   "UpThreshold": 40,
 	   "DownThreshold": 0,
 	   "FanSpeed": 0.0
 	  },
 	  {
-	   "UpThreshold": 40,
+	   "UpThreshold": 42,
 	   "DownThreshold": 40,
 	   "FanSpeed": 30.0
 	  },
 	  {
-	   "UpThreshold": 42,
+	   "UpThreshold": 44,
 	   "DownThreshold": 41,
 	   "FanSpeed": 32.0
 	  },
 	  {
-	   "UpThreshold": 44,
+	   "UpThreshold": 48,
 	   "DownThreshold": 43,
 	   "FanSpeed": 34.0
 	  },
 	  {
-	   "UpThreshold": 48,
+	   "UpThreshold": 52,
 	   "DownThreshold": 46,
 	   "FanSpeed": 36.0
 	  },
 	  {
-	   "UpThreshold": 52,
+	   "UpThreshold": 54,
 	   "DownThreshold": 50,
 	   "FanSpeed": 38.0
 	  },
 	  {
-	   "UpThreshold": 54,
+	   "UpThreshold": 58,
 	   "DownThreshold": 53,
 	   "FanSpeed": 41.0
 	  },
 	  {
-	   "UpThreshold": 58,
+	   "UpThreshold": 62,
 	   "DownThreshold": 56,
 	   "FanSpeed": 44.0
 	  },
 	  {
-	   "UpThreshold": 62,
+	   "UpThreshold": 64,
 	   "DownThreshold": 60,
 	   "FanSpeed": 47.0
 	  },
 	  {
-	   "UpThreshold": 64,
+	   "UpThreshold": 68,
 	   "DownThreshold": 63,
 	   "FanSpeed": 50.0
 	  },
 	  {
-	   "UpThreshold": 68,
+	   "UpThreshold": 72,
 	   "DownThreshold": 66,
 	   "FanSpeed": 55.0
 	  },
 	  {
-	   "UpThreshold": 72,
+	   "UpThreshold": 74,
 	   "DownThreshold": 70,
 	   "FanSpeed": 61.0
 	  },
 	  {
-	   "UpThreshold": 74,
+	   "UpThreshold": 78,
 	   "DownThreshold": 73,
 	   "FanSpeed": 68.0
 	  },
 	  {
-	   "UpThreshold": 78,
+	   "UpThreshold": 82,
 	   "DownThreshold": 76,
 	   "FanSpeed": 76.0
 	  },
 	  {
-	   "UpThreshold": 82,
+	   "UpThreshold": 84,
 	   "DownThreshold": 80,
 	   "FanSpeed": 85.0
 	  },
 	  {
-	   "UpThreshold": 84,
+	   "UpThreshold": 88,
 	   "DownThreshold": 83,
 	   "FanSpeed": 94.0
 	  },
 	  {
-	   "UpThreshold": 88,
+	   "UpThreshold": 90,
 	   "DownThreshold": 86,
 	   "FanSpeed": 100.0
 	  }
@@ -118,87 +118,87 @@
 	 "FanDisplayName": "AMD RX560X",
 	 "TemperatureThresholds": [
 	  {
-	   "UpThreshold": 0,
+	   "UpThreshold": 40,
 	   "DownThreshold": 0,
 	   "FanSpeed": 0.0
 	  },
 	  {
-	   "UpThreshold": 40,
+	   "UpThreshold": 42,
 	   "DownThreshold": 40,
 	   "FanSpeed": 22.0
 	  },
 	  {
-	   "UpThreshold": 42,
+	   "UpThreshold": 44,
 	   "DownThreshold": 41,
 	   "FanSpeed": 24.0
 	  },
 	  {
-	   "UpThreshold": 44,
+	   "UpThreshold": 48,
 	   "DownThreshold": 43,
 	   "FanSpeed": 26.0
 	  },
 	  {
-	   "UpThreshold": 48,
+	   "UpThreshold": 52,
 	   "DownThreshold": 46,
 	   "FanSpeed": 28.0
 	  },
 	  {
-	   "UpThreshold": 52,
+	   "UpThreshold": 54,
 	   "DownThreshold": 50,
 	   "FanSpeed": 30.0
 	  },
 	  {
-	   "UpThreshold": 54,
+	   "UpThreshold": 58,
 	   "DownThreshold": 53,
 	   "FanSpeed": 34.0
 	  },
 	  {
-	   "UpThreshold": 58,
+	   "UpThreshold": 62,
 	   "DownThreshold": 56,
 	   "FanSpeed": 38.0
 	  },
 	  {
-	   "UpThreshold": 62,
+	   "UpThreshold": 64,
 	   "DownThreshold": 60,
 	   "FanSpeed": 42.0
 	  },
 	  {
-	   "UpThreshold": 64,
+	   "UpThreshold": 68,
 	   "DownThreshold": 63,
 	   "FanSpeed": 46.0
 	  },
 	  {
-	   "UpThreshold": 68,
+	   "UpThreshold": 72,
 	   "DownThreshold": 66,
 	   "FanSpeed": 52.0
 	  },
 	  {
-	   "UpThreshold": 72,
+	   "UpThreshold": 74,
 	   "DownThreshold": 70,
 	   "FanSpeed": 59.0
 	  },
 	  {
-	   "UpThreshold": 74,
+	   "UpThreshold": 78,
 	   "DownThreshold": 73,
 	   "FanSpeed": 67.0
 	  },
 	  {
-	   "UpThreshold": 78,
+	   "UpThreshold": 82,
 	   "DownThreshold": 76,
 	   "FanSpeed": 76.0
 	  },
 	  {
-	   "UpThreshold": 82,
+	   "UpThreshold": 84,
 	   "DownThreshold": 80,
 	   "FanSpeed": 86.0
 	  },
 	  {
-	   "UpThreshold": 84,
+	   "UpThreshold": 88,
 	   "DownThreshold": 83,
 	   "FanSpeed": 96.0
 	  },
 	  {
-	   "UpThreshold": 88,
+	   "UpThreshold": 90,
 	   "DownThreshold": 86,
 	   "FanSpeed": 100.0
 	  }

--- a/src/fan.c
+++ b/src/fan.c
@@ -22,6 +22,7 @@ Error* Fan_Init(Fan* self, FanConfiguration* cfg, int criticalTemperature, bool 
   my.maxSpeedValueRead    = same ? my.maxSpeedValueWrite : cfg->MaxSpeedValueRead;
   my.minSpeedValueReadAbs = min(my.minSpeedValueRead, my.maxSpeedValueRead);
   my.maxSpeedValueReadAbs = max(my.minSpeedValueRead, my.maxSpeedValueRead);
+  my.fanSpeedSteps        = my.maxSpeedValueReadAbs - my.minSpeedValueReadAbs;
 
   // TODO #1: How to handle empty TemperatureThresholds? [see model_config.c]
   if (! cfg->TemperatureThresholds.size)
@@ -155,12 +156,16 @@ Error* Fan_UpdateCurrentSpeed(Fan* self) {
   for (range(int, i, 0, 3)) {
     e = Fan_ECReadValue(self, &speed);
     if (speed >= my.minSpeedValueReadAbs && speed <= my.maxSpeedValueReadAbs) {
-      my.currentSpeed = Fan_FanSpeedToPercentage(self, speed);
       break;
     }
   }
 
+  my.currentSpeed = Fan_FanSpeedToPercentage(self, speed);
   return e;
+}
+
+int Fan_GetSpeedSteps(Fan* self) {
+  return my.fanSpeedSteps;
 }
 
 Error* Fan_ECReset(Fan* self) {

--- a/src/fan.h
+++ b/src/fan.h
@@ -23,6 +23,7 @@ struct Fan {
   int   maxSpeedValueRead;         /*const*/
   int   minSpeedValueReadAbs;      /*const*/
   int   maxSpeedValueReadAbs;      /*const*/
+  int   fanSpeedSteps;             /*const*/
   int   criticalTemperatureOffset;
 
   ThresholdManager threshMan;
@@ -37,6 +38,7 @@ Error* Fan_Init(Fan*, FanConfiguration*, int criticalTemperature, bool readWrite
 Error* Fan_UpdateCurrentSpeed(Fan*);
 float  Fan_GetCurrentSpeed(Fan*);
 float  Fan_GetTargetSpeed(const Fan*);
+int    Fan_GetSpeedSteps(Fan*);
 
 void   Fan_SetTemperature(Fan*, float temperature);
 Error* Fan_SetFixedSpeed(Fan*, float speed);

--- a/src/info.c
+++ b/src/info.c
@@ -70,7 +70,7 @@ Error* Info_Write(Config* cfg, float temperature, bool readonly, array_of(Fan)* 
       Bool_ToStr[fan->isCritical],
       Fan_GetCurrentSpeed(fan),
       Fan_GetTargetSpeed(fan),
-      0,
+      Fan_GetSpeedSteps(fan),
       (++i != fans->size ? ',' : ' ')
     );
   }


### PR DESCRIPTION
- Added support for Fan Speed Steps.
- Made changes to C/Python clients to include "zenpower" for AMD Zen family CPUs in `wait_for_hwmon`.
- Made changes to C/Python clients to delete the nbfc state file when the service is stopped so that `nbfc status` will correctly report "service not running".
- Improved formatting in C client for `nbfc status` and error messages.
- Updated the "Acer Nitro AN515-43.json" config to account for the 0 `UpThreshold` entry since it was not picked up by https://github.com/nbfc-linux/nbfc-linux/commit/376ce6b278804800e9c067827584ddf0b3de1741 (it was a manually added json).
- Fixed incorrect current fan speed reporting when the fan speed is 0 on some notebooks*.

*I personally had this issue, and it seems it was caused by the range check in the for-loop of `Fan_UpdateCurrentSpeed` (src/fan.c). For example, when the fan speed is 0 on my HP EliteBook 8560p, `Fan_ECReadValue` returns 255 (FF) which is outside of the `minSpeedValueReadAbs`/`maxSpeedValueReadAbs` range. As such, the `my.currentSpeed` update was never being run. The solution was to move the update outside of the for-loop, which is [in line with the original NBFC service](https://github.com/hirschmann/nbfc/blob/fc9fb970155607d9ebc994f9e99c8ee09121e628/Core/StagWare.FanControl/Fan.cs#L158).