### PR TITLE
Add default temperature thresholds

### DIFF
--- a/share/nbfc/configs/Acer Aspire 5738G.json
+++ b/share/nbfc/configs/Acer Aspire 5738G.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Aspire 7551G.json
+++ b/share/nbfc/configs/Acer Aspire 7551G.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Aspire 7735.json
+++ b/share/nbfc/configs/Acer Aspire 7735.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 102,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 196,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Aspire 7740G.json
+++ b/share/nbfc/configs/Acer Aspire 7740G.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Aspire 7741G.json
+++ b/share/nbfc/configs/Acer Aspire 7741G.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Aspire LT-10Q.json
+++ b/share/nbfc/configs/Acer Aspire LT-10Q.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 255,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 0,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Aspire S3.json
+++ b/share/nbfc/configs/Acer Aspire S3.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Acer Extensa 5220.json
+++ b/share/nbfc/configs/Acer Extensa 5220.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Asus F5SR.json
+++ b/share/nbfc/configs/Asus F5SR.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 8,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 9,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Fujitsu ESPRIMO Mobile V5505.json
+++ b/share/nbfc/configs/Fujitsu ESPRIMO Mobile V5505.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/HP Compaq 615.json
+++ b/share/nbfc/configs/HP Compaq 615.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 99,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/HP Compaq 625.json
+++ b/share/nbfc/configs/HP Compaq 625.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 99,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/HP Compaq 8710p.json
+++ b/share/nbfc/configs/HP Compaq 8710p.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 100,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 30,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/HP ENVY m6 Sleekbook.json
+++ b/share/nbfc/configs/HP ENVY m6 Sleekbook.json
@@ -11,7 +11,38 @@
 	 "MaxSpeedValue": 41,
 	 "ResetRequired": false,
 	 "FanSpeedResetValue": 0,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 85,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": [
 	  {
 	   "FanSpeedPercentage": 76.92307692307693,

--- a/share/nbfc/configs/HP Pavilion 14-v066br.json
+++ b/share/nbfc/configs/HP Pavilion 14-v066br.json
@@ -15,7 +15,38 @@
 	 "MaxSpeedValueRead": 0,
 	 "ResetRequired": false,
 	 "FanSpeedResetValue": 0,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 89,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/HP ProBook 4710s.json
+++ b/share/nbfc/configs/HP ProBook 4710s.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 100,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/HP ProBook 650 G2.json
+++ b/share/nbfc/configs/HP ProBook 650 G2.json
@@ -36,13 +36,8 @@
 	 "FanSpeedPercentageOverrides": [
 	  {
 	   "FanSpeedPercentage": 0.0,
-	   "FanSpeedValue": 254,
-	   "TargetOperation": "ReadWrite"
-	  },
-	  {
-	   "FanSpeedPercentage": 0.0,
 	   "FanSpeedValue": 255,
-	   "TargetOperation": "Read"
+	   "TargetOperation": "ReadWrite"
 	  }
 	 ]
 	}

--- a/share/nbfc/configs/Lenovo Yoga 3 14.json
+++ b/share/nbfc/configs/Lenovo Yoga 3 14.json
@@ -13,7 +13,38 @@
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 0,
 	 "FanDisplayName": "Fan1",
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": [
 	  {
 	   "FanSpeedPercentage": 100.0,

--- a/share/nbfc/configs/Medion Akoya P6612.json
+++ b/share/nbfc/configs/Medion Akoya P6612.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Medion Akoya P6630.json
+++ b/share/nbfc/configs/Medion Akoya P6630.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 98,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 255,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Packard Bell Easynote TJ65.json
+++ b/share/nbfc/configs/Packard Bell Easynote TJ65.json
@@ -14,7 +14,38 @@
 	 "MaxSpeedValueRead": 0,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 196,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/share/nbfc/configs/Sony Vaio SVE1711.json
+++ b/share/nbfc/configs/Sony Vaio SVE1711.json
@@ -12,7 +12,38 @@
 	 "MaxSpeedValue": 102,
 	 "ResetRequired": true,
 	 "FanSpeedResetValue": 196,
-	 "TemperatureThresholds": [],
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }
+	 ],
 	 "FanSpeedPercentageOverrides": []
 	}
  ],

--- a/tools/config_to_json.py
+++ b/tools/config_to_json.py
@@ -1,5 +1,40 @@
 #!/usr/bin/python3 -B
 
+def default_temperature_thresholds():
+    defaults = """
+          [{
+	   "UpThreshold": 0,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 48,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 63,
+	   "DownThreshold": 55,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 59,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 63,
+	   "FanSpeed": 70.0
+	  },
+	  {
+	   "UpThreshold": 71,
+	   "DownThreshold": 67,
+	   "FanSpeed": 100.0
+	  }]"""
+
+    return json.loads(defaults)
+
 import sys, os, json, config, argparse
 
 argp = argparse.ArgumentParser()
@@ -24,6 +59,9 @@ for infile in opts.infile:
         p = json.loads(s)
         for fan_configuration in p['FanConfigurations']:
             thresholds = fan_configuration.get('TemperatureThresholds')
+
+            if not thresholds:
+                thresholds = default_temperature_thresholds()
             if thresholds:
                 thresholds.sort(key=lambda x: x['UpThreshold'])
 


### PR DESCRIPTION
The tool to convert nbfc configs to json just left empty arrays for
temperature thresholds.

This PR fixes this by replacing thresholds with default values if
they are empty in the config. The defaults are taken from default
values in original nbfc.

I've also run the tool against the original nbfc tool to update the
configs.