### PR TITLE
Add Asus UX550VD support

### DIFF
--- a/share/nbfc/configs/Asus Zenbook Pro UX550VD.json
+++ b/share/nbfc/configs/Asus Zenbook Pro UX550VD.json
@@ -1,0 +1,151 @@
+{
+ "NotebookModel": "Asus Zenbook Pro UX550VD",
+ "Author": "rustyx",
+ "EcPollInterval": 200,
+ "ReadWriteWords": false,
+ "CriticalTemperature": 85,
+ "FanConfigurations": [
+	{
+	 "ReadRegister": 151,
+	 "WriteRegister": 151,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 8,
+	 "IndependentReadMinMaxValues": false,
+	 "MinSpeedValueRead": 0,
+	 "MaxSpeedValueRead": 0,
+	 "ResetRequired": true,
+	 "FanSpeedResetValue": 8,
+	 "FanDisplayName": "Left Fan",
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 41,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 47,
+	   "DownThreshold": 38,
+	   "FanSpeed": 12.5
+	  },
+	  {
+	   "UpThreshold": 51,
+	   "DownThreshold": 46,
+	   "FanSpeed": 25.0
+	  },
+	  {
+	   "UpThreshold": 55,
+	   "DownThreshold": 50,
+	   "FanSpeed": 37.5
+	  },
+	  {
+	   "UpThreshold": 62,
+	   "DownThreshold": 54,
+	   "FanSpeed": 50
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 59,
+	   "FanSpeed": 62.5
+	  },
+	  {
+	   "UpThreshold": 70,
+	   "DownThreshold": 63,
+	   "FanSpeed": 75
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 87.5
+	  },
+	  {
+	   "UpThreshold": 85,
+	   "DownThreshold": 72,
+	   "FanSpeed": 100.0
+	  }
+	 ],
+	 "FanSpeedPercentageOverrides": []
+	},
+	{
+	 "ReadRegister": 152,
+	 "WriteRegister": 152,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 8,
+	 "IndependentReadMinMaxValues": false,
+	 "MinSpeedValueRead": 0,
+	 "MaxSpeedValueRead": 0,
+	 "ResetRequired": true,
+	 "FanSpeedResetValue": 8,
+	 "FanDisplayName": "Right Fan",
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 46,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 51,
+	   "DownThreshold": 43,
+	   "FanSpeed": 12.5
+	  },
+	  {
+	   "UpThreshold": 54,
+	   "DownThreshold": 49,
+	   "FanSpeed": 25.0
+	  },
+	  {
+	   "UpThreshold": 57,
+	   "DownThreshold": 51,
+	   "FanSpeed": 37.5
+	  },
+	  {
+	   "UpThreshold": 62,
+	   "DownThreshold": 54,
+	   "FanSpeed": 50
+	  },
+	  {
+	   "UpThreshold": 66,
+	   "DownThreshold": 59,
+	   "FanSpeed": 62.5
+	  },
+	  {
+	   "UpThreshold": 70,
+	   "DownThreshold": 63,
+	   "FanSpeed": 75
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 67,
+	   "FanSpeed": 87.5
+	  },
+	  {
+	   "UpThreshold": 85,
+	   "DownThreshold": 72,
+	   "FanSpeed": 100.0
+	  }
+	 ],
+	 "FanSpeedPercentageOverrides": []
+	}
+ ],
+ "RegisterWriteConfigurations": [
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnWriteFanSpeed",
+	 "Register": 160,
+	 "Value": 8,
+	 "ResetRequired": true,
+	 "ResetValue": 8,
+	 "ResetWriteMode": "Set",
+	 "Description": "Left FAN"
+	},
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnWriteFanSpeed",
+	 "Register": 166,
+	 "Value": 8,
+	 "ResetRequired": true,
+	 "ResetValue": 8,
+	 "ResetWriteMode": "Set",
+	 "Description": "Right FAN"
+	}
+ ]
+}


### PR DESCRIPTION
This adds support for Asus UX550VD.

Tested and fine-tuned on Ubuntu 20.04 and Debian 11 for about a month 👍