### PR TITLE
Supported compilation with `acpi_ec`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,20 @@ else
 	LDFLAGS  = -s
 endif
 
+EC_MODULE = 
+ifeq ($(EMBEDDED_CONTROLLER), acpi_ec)
+override EC_MODULE += -DACPI_EC
+else ifeq ($(EMBEDDED_CONTROLLER), ec_sys)
+override EC_MODULE +=
+else ifeq ($(EMBEDDED_CONTROLLER), )
+override EC_MODULE +=
+else
+$(error Unsupported embeded controller module: $(EMBEDDED_CONTROLLER))
+endif
+
 override LDLIBS   += -lm
 override CPPFLAGS += -DCONFDIR=\"$(confdir)\" -DDATADIR=\"$(sharedir)\"
+override CPPFLAGS += $(EC_MODULE)
 
 CORE  = src/nbfc_service src/ec_probe
 PROGS = $(CORE) src/nbfc

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The preferred way of running nbfc is using the `ECSysLinux` implementation, whic
 There is also an alternative implementation which uses `/dev/port`, called `ec_linux`.
 It can be specified on the commandline using `--embedded-controller=ec_linux` and permanently set in `/etc/nbfc/nbfc.json` with `"EmbeddedControllerType": "ec_linux"`.
 
-For running NBFC with Secure Boot and Lockdown Kernel, see [acpi\_ec](https://github.com/MusiKid/acpi_ec)
+Many Linux distributions do not provide the `ec_sys` module, and the module should be compiled manually. Alternatively, the [`acpi_ec`](https://github.com/MusiKid/acpi_ec) module can be used. The `acpi_ec` module comes with a DKMS config script, which automatically rebuilds the `acpi_ec` module when a new kernel is installed and supports running NBFC with Secure Boot and Lockdown Kernel. To compile with the `acpi_ec` module, use the command:
+
+`make EMBEDDED_CONTROLLER=acpi_ec`
 
 Shell autocompletion
 --------------------

--- a/src/ec_sys_linux.c
+++ b/src/ec_sys_linux.c
@@ -11,7 +11,11 @@
 
 #define EC_SysLinux_ACPI_EC_Path "/dev/ec"
 #define EC_SysLinux_EC0_IO_Path  "/sys/kernel/debug/ec/ec0/io"
+#if defined(ACPI_EC)
+#define EC_SysLinux_Module_Cmd   "modprobe acpi_ec write_support=1"
+#else
 #define EC_SysLinux_Module_Cmd   "modprobe ec_sys write_support=1"
+#endif
 
 static int EC_SysLinux_FD = -1;
 


### PR DESCRIPTION
The makefile doesn't support the `acpi_ec` module. In this example, I add a flag to select the embedded controller module. Tested on Asus ROG GL702ZC with Debian 11 for about a week.