### PR TITLE
Initial openrc support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ bindir   = $(PREFIX)/bin
 confdir  = $(PREFIX)/etc
 sharedir = $(PREFIX)/share
 sysddir  = $(PREFIX)/lib/systemd/system
+orcdir   = $(PREFIX)/etc/init.d
 
 ifeq ($(BUILD), debug)
 	CFLAGS   = -Og -g
@@ -37,12 +38,19 @@ install-configs:
 	mkdir -p $(DESTDIR)$(sharedir)/nbfc/configs
 	cp -r share/nbfc/configs/* $(DESTDIR)$(sharedir)/nbfc/configs
 
-nbfc_service.service: etc/systemd/system/nbfc_service.service.in
+nbfc_service-systemd: etc/systemd/system/nbfc_service.service.in
 	sed 's:@BINDIR@:'$(bindir)':' < $< >$@
 
-install-systemd:    nbfc_service.service
+install-systemd:    nbfc_service-systemd
 	# /usr/local/lib/systemd/system
-	install -Dm 644 nbfc_service.service     $(DESTDIR)$(sysddir)/nbfc_service.service
+	install -Dm 644 nbfc_service-systemd     $(DESTDIR)$(sysddir)/nbfc_service.service
+
+nbfc_service-openrc: etc/init.d/nbfc_service.in
+	sed 's:@BINDIR@:'$(bindir)':' < $< >$@
+
+install-openrc:     nbfc_service-openrc
+	# /usr/local/etc/init.d
+	install -Dm 755 nbfc_service-openrc		 $(DESTDIR)$(orcdir)/nbfc_service
 
 install-docs:
 	install -Dm 644 doc/ec_probe.1           $(DESTDIR)$(sharedir)/man/man1/ec_probe.1
@@ -75,6 +83,9 @@ uninstall:
 	
 	# /usr/local/lib/systemd/system
 	rm -f $(DESTDIR)$(sysddir)/nbfc_service.service
+
+	# /usr/local/etc/init.d
+	rm -f $(DESTDIR)$(orcdir)/nbfc_service
 	
 	# /usr/local/share/nbfc/configs
 	rm -rf $(DESTDIR)$(sharedir)/nbfc

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Installation
 
 - In general:
   - `make PREFIX=/usr confdir=/etc && sudo make PREFIX=/usr confdir=/etc install`
+  - With openrc support (`make PREFIX=/usr confdir=/etc && sudo make PREFIX=/usr confdir=/etc install install-openrc`)
 
 Getting started
 ---------------

--- a/etc/init.d/nbfc_service.in
+++ b/etc/init.d/nbfc_service.in
@@ -1,0 +1,30 @@
+#!/sbin/openrc-run
+# Copyright 2023 Avishek Sen
+# Distributed under the terms of the GNU General Public License v3
+
+command="@BINDIR@/nbfc"
+pidfile="/run/${RC_SVCNAME}.pid"
+description="NoteBook FanControl service"
+
+depend() {
+	need localmount
+	after modules
+}
+
+start() {
+	ebegin "Starting nbfc service"
+	${command} start
+	eend $? "Failed to start!"
+}
+
+stop() {
+	ebegin "Stopping nbfc service"
+	${command} stop
+	eend $? "Failed to stop!"
+}
+
+start_pre() {
+	ebegin "Waiting for /sys/class/hwmon/hwmon* files"
+	${command} wait-for-hwmon
+	eend $? "Failed to look for required files!"
+}


### PR DESCRIPTION
The default openrc service installation directory `orcdir` has been set keeping gentoo in mind. Users on other openrc based systems may need to change it (Eg, archlinux on openrc uses /etc/openrc/init.d)