### PR TITLE
remove hashbangs

### DIFF
--- a/completion/bash/ec_probe
+++ b/completion/bash/ec_probe
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 _ec_probe() {
   local cur prev words cword split args w
   _init_completion -s || return

--- a/completion/bash/nbfc
+++ b/completion/bash/nbfc
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 _nbfc() {
   local cur prev words cword split args w
   _init_completion -s || return

--- a/completion/bash/nbfc_service
+++ b/completion/bash/nbfc_service
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 _nbfc_service() {
   local cur prev words cword split args w
   _init_completion -s || return


### PR DESCRIPTION
As part of creation of Debian package I noticed that lintian (sanity checker) complains about superflous hashbangs in bash completion files:

fenio@debian:~/pakiety/nbfc$ lintian -i *changes
N:
W: nbfc: bash-completion-with-hashbang /bin/bash [usr/share/bash-completion/completions/ec_probe:1]
N: 
N:   This file starts with the #! sequence that marks interpreted scripts, but it is a bash completion script that is merely intended to be sourced.
N:   
N:   Please remove the line with hashbang, including any designated interpreter.
N: 
N:   Please refer to https://salsa.debian.org/lintian/lintian/-/merge_requests/292#note_139494 for details.
N: 
N:   Visibility: warning
N:   Show-Always: no
N:   Check: shell/bash/completion
N: 
N:
W: nbfc: bash-completion-with-hashbang /bin/bash [usr/share/bash-completion/completions/nbfc:1]
N:
W: nbfc: bash-completion-with-hashbang /bin/bash [usr/share/bash-completion/completions/nbfc_service:1]

This PR removes them.