### PR TITLE
fix section for manpage

### DIFF
--- a/doc/nbfc_service.json.5
+++ b/doc/nbfc_service.json.5
@@ -1,5 +1,5 @@
 .nh
-.TH NBFC\_SERVICE 1 "MARCH 2021" Notebook FanControl
+.TH NBFC\_SERVICE 5 "MARCH 2021" Notebook FanControl
 .SH NAME
 .PP
 nbfc\_service.json \- Notebook FanControl service configuration


### PR DESCRIPTION
As part of creation of Debian package I noticed that lintian (sanity checker) complains  about mismatch between mapage section and actual category manpage fits into:

W: nbfc: wrong-manual-section 5 != 1 [usr/share/man/man5/nbfc_service.json.5.gz:2]
N: 
N:   A manual page usually should contain a .TH header, specifying the section. The section in this manual page doesn't match with the section in the filename.
N: 
N:   Please refer to the groff_man(7) manual page and the man(1) manual page for details.
N: 
N:   Visibility: warning
N:   Show-Always: no
N:   Check: documentation/manual
N:   Renamed from: manpage-section-mismatch

This PR fixes it.