### PR TITLE
support an515-57 and an515-58

### DIFF
--- a/share/nbfc/configs/Acer Nitro AN515-57.json
+++ b/share/nbfc/configs/Acer Nitro AN515-57.json
@@ -1,0 +1,231 @@
+{
+ "NotebookModel": "Acer Nitro AN515-57",
+ "Author": "ltsdw",
+ "EcPollInterval": 3000,
+ "ReadWriteWords": true,
+ "CriticalTemperature": 95,
+ "FanConfigurations": [
+	{
+	 "ReadRegister": 19,
+	 "WriteRegister": 55,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 100,
+	 "IndependentReadMinMaxValues": false,
+	 "MinSpeedValueRead": 0,
+	 "MaxSpeedValueRead": 0,
+	 "ResetRequired": true,
+	 "FanSpeedResetValue": 50,
+	 "FanDisplayName": "CPU fan",
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 40,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 45,
+	   "DownThreshold": 40,
+	   "FanSpeed": 20.0
+	  },
+	  {
+	   "UpThreshold": 50,
+	   "DownThreshold": 45,
+	   "FanSpeed": 35.0
+	  },
+	  {
+	   "UpThreshold": 54,
+	   "DownThreshold": 50,
+	   "FanSpeed": 38.0
+	  },
+	  {
+	   "UpThreshold": 58,
+	   "DownThreshold": 54,
+	   "FanSpeed": 41.0
+	  },
+	  {
+	   "UpThreshold": 62,
+	   "DownThreshold": 58,
+	   "FanSpeed": 44.0
+	  },
+	  {
+	   "UpThreshold": 64,
+	   "DownThreshold": 62,
+	   "FanSpeed": 47.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 62,
+	   "FanSpeed": 50.0
+	  },
+	  {
+	   "UpThreshold": 72,
+	   "DownThreshold": 68,
+	   "FanSpeed": 55.0
+	  },
+	  {
+	   "UpThreshold": 74,
+	   "DownThreshold": 72,
+	   "FanSpeed": 61.0
+	  },
+	  {
+	   "UpThreshold": 78,
+	   "DownThreshold": 74,
+	   "FanSpeed": 68.0
+	  },
+	  {
+	   "UpThreshold": 82,
+	   "DownThreshold": 78,
+	   "FanSpeed": 76.0
+	  },
+	  {
+	   "UpThreshold": 84,
+	   "DownThreshold": 82,
+	   "FanSpeed": 85.0
+	  },
+	  {
+	   "UpThreshold": 88,
+	   "DownThreshold": 84,
+	   "FanSpeed": 94.0
+	  },
+	  {
+	   "UpThreshold": 95,
+	   "DownThreshold": 88,
+	   "FanSpeed": 100.0
+	  }
+	 ],
+	 "FanSpeedPercentageOverrides": []
+	},
+	{
+	 "ReadRegister": 21,
+	 "WriteRegister": 58,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 100,
+	 "IndependentReadMinMaxValues": false,
+	 "MinSpeedValueRead": 0,
+	 "MaxSpeedValueRead": 0,
+	 "ResetRequired": true,
+	 "FanSpeedResetValue": 50,
+	 "FanDisplayName": "GPU fan",
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 40,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+	   "UpThreshold": 42,
+	   "DownThreshold": 40,
+	   "FanSpeed": 22.0
+	  },
+	  {
+	   "UpThreshold": 44,
+	   "DownThreshold": 42,
+	   "FanSpeed": 24.0
+	  },
+	  {
+	   "UpThreshold": 48,
+	   "DownThreshold": 44,
+	   "FanSpeed": 26.0
+	  },
+	  {
+	   "UpThreshold": 52,
+	   "DownThreshold": 48,
+	   "FanSpeed": 28.0
+	  },
+	  {
+	   "UpThreshold": 54,
+	   "DownThreshold": 52,
+	   "FanSpeed": 30.0
+	  },
+	  {
+	   "UpThreshold": 58,
+	   "DownThreshold": 54,
+	   "FanSpeed": 34.0
+	  },
+	  {
+	   "UpThreshold": 62,
+	   "DownThreshold": 58,
+	   "FanSpeed": 38.0
+	  },
+	  {
+	   "UpThreshold": 64,
+	   "DownThreshold": 62,
+	   "FanSpeed": 42.0
+	  },
+	  {
+	   "UpThreshold": 68,
+	   "DownThreshold": 64,
+	   "FanSpeed": 46.0
+	  },
+	  {
+	   "UpThreshold": 72,
+	   "DownThreshold": 68,
+	   "FanSpeed": 52.0
+	  },
+	  {
+	   "UpThreshold": 74,
+	   "DownThreshold": 72,
+	   "FanSpeed": 59.0
+	  },
+	  {
+	   "UpThreshold": 78,
+	   "DownThreshold": 74,
+	   "FanSpeed": 67.0
+	  },
+	  {
+	   "UpThreshold": 82,
+	   "DownThreshold": 78,
+	   "FanSpeed": 76.0
+	  },
+	  {
+	   "UpThreshold": 84,
+	   "DownThreshold": 82,
+	   "FanSpeed": 86.0
+	  },
+	  {
+	   "UpThreshold": 88,
+	   "DownThreshold": 84,
+	   "FanSpeed": 96.0
+	  },
+	  {
+	   "UpThreshold": 95,
+	   "DownThreshold": 88,
+	   "FanSpeed": 100.0
+	  }
+	 ],
+	 "FanSpeedPercentageOverrides": []
+	}
+ ],
+ "RegisterWriteConfigurations": [
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnInitialization",
+	 "Register": 3,
+	 "Value": 17,
+	 "ResetRequired": true,
+	 "ResetValue": 0,
+	 "ResetWriteMode": "Set",
+	 "Description": "Make manual fan control possible"
+	},
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnInitialization",
+	 "Register": 34,
+	 "Value": 12,
+	 "ResetRequired": true,
+	 "ResetValue": 4,
+	 "ResetWriteMode": "Set",
+	 "Description": "CPU fan manual mode"
+	},
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnInitialization",
+	 "Register": 33,
+	 "Value": 48,
+	 "ResetRequired": true,
+	 "ResetValue": 16,
+	 "ResetWriteMode": "Set",
+	 "Description": "GPU fan manual mode"
+	}
+ ]
+}


### PR DESCRIPTION
It may be needed to tune the register 3, right now it only enables the possibility for manual fan control, but does not account for battery health/calibration mode, or anything else, also its reset value here is set to 0, meaning no fan control, or any health/calibration mode for the battery.

Also I left the bit about CoolBoost out of it, as it seems it only works on auto mode, so doesn't make sense enabling it while manually controlling the fans with nbfc service, neither does enabling or disabling it when stopping the process, as it would set the register 0x03 to 0, which would also ignore the CoolBoost register bit.

Also thanks to @kensad-ops for its findings about the register 0x03.

This solves the #65 