### PR TITLE
added JSON schema for nbfc config file

### DIFF
--- a/tools/FanControlConfigV3-schema.json
+++ b/tools/FanControlConfigV3-schema.json
@@ -1,0 +1,335 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$comment": "Schema for nbfc-linux for controlling fans of notebooks",
+  "type": "object",
+  "properties": {
+    "LegacyTemperatureThresholdsBehaviour": {
+      "type": "boolean",
+      "description": "Backwards compatibilty with configuration files from the original NBFC project. The default is false. Do not use this option for new configuration files.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "EmbeddedControllerType": {
+      "type": "string",
+      "description": "The preferred way of running nbfc. If not given, the embedded controller type will be automatically selected.",
+      "default": "\"\"",
+      "oneOf": [
+        {
+          "title": "ec_sys",
+          "description": "Use the ec_sys kernel module for writing to the embedded controller."
+        },
+        {
+          "title": "acpi_ec",
+          "description": "Use the acpi_ec kernel module for writing to the embedded controller."
+        },
+        {
+          "title": "dev_port",
+          "description": "Write to the embedded controller using /dev/port."
+        },
+        {
+          "title": "dummy",
+          "description": "Don't write to the embedded controller at all."
+        },
+        {
+          "title": "\"\"",
+          "description": "The embedded controller type will be automatically selected."
+        }
+      ]
+    },
+    "NotebookModel": {
+      "type": "string",
+      "description": "The Notebook Model as described in your BIOS. See `sudo dmidecode -s system-product-name`."
+    },
+    "Author": {
+      "type": "string",
+      "description": "The Author of the config file. Enter whatever you want.",
+      "default": "\"\""
+    },
+    "EcPollInterval": {
+      "type": "integer",
+      "description": "Defines how often NBFC polls the EC for changes (in miliseconds).",
+      "default": "3000",
+      "minimum": 1,
+      "maximum": 32768
+    },
+    "ReadWriteWords": {
+      "type": "boolean",
+      "description": "If `true`, NBFC will combine two 8 bit registers to one 16-bit register when reading from or writing to the EC registers.",
+      "default": false,
+      "enum": [true, false]
+    },
+    "CriticalTemperature": {
+      "type": "integer",
+      "description": "If the temperature exceeds this threshold, NBFC will ignore all Temperature threshold elements and set the fan to 100% speed until the temperature drops below (`CriticalTemperature` - `CriticalTemperatureOffset`)",
+      "default": 75,
+      "minimum": 0,
+      "maximum": 100
+    },
+    "CriticalTemperatureOffset": {
+      "type": "integer",
+      "description": "See `CriticalTemperature`",
+      "default": 15,
+      "minimum": 32768
+    },
+    "TargetFanSpeeds": {
+      "type": "array",
+      "description": "This holds the fixed speed of the fans. A value of -1 means the fan should be left in auto mode.",
+      "minProperties": 0,
+      "items": [{ "$ref": "#/$defs/word" }, { "const": -1 }]
+    },
+    "FanConfigurations": {
+      "type": "array",
+      "description": "Array of at least one FanConfiguration",
+      "minProperties": 1,
+      "items": [
+        {
+          "type": "object",
+          "title": "FanConfiguration",
+          "description": "Defines how NBFC controls a fan",
+          "properties": {
+            "ReadRegister": {
+              "$ref": "#/$defs/byte",
+              "description": "The register from which NBFC reads the fan speed."
+            },
+            "WriteRegister": {
+              "$ref": "#/$defs/byte",
+              "description": "The register which NBFC uses to control the fan"
+            },
+            "MinSpeedValue": {
+              "$ref": "#/$defs/word",
+              "description": "The value which puts the fan to the lowest possible speed (usually this stops the fan). Must be an integer between 0 and 255 or 0 and 65535 if ReadWriteWords is `true`. Note: MinSpeedValue does not necessarily have to be smaller than MaxSpeedValue"
+            },
+            "MaxSpeedValue": {
+              "$ref": "#/$defs/word",
+              "description": "The value which puts the fan to the highest possible fan speed."
+            },
+            "IndependentReadMinMaxValues": {
+              "type": "boolean",
+              "default": false,
+              "enum": [true, false],
+              "description": "Defines if independent minimum/maximum values should be applied for read operations"
+            },
+            "MinSpeedValueRead": {
+              "$ref": "#/$defs/word",
+              "description": "The value which corresponds to the lowest possible fan speed. Will be ignored if IndependentReadMinMaxValues is `false`."
+            },
+            "MaxSpeedValueRead": {
+              "$ref": "#/$defs/word",
+              "description": "The value which  corresponds to the highest possible fan speed. Will be ignored if IndependentReadMinMaxValues is `false`."
+            },
+            "ResetRequired": {
+              "type": "boolean",
+              "default": false,
+              "enum": [true, false],
+              "description": "Defines if the EC should be reset before the service is shut down."
+            },
+            "FanSpeedResetValue": {
+              "$ref": "#/$defs/word",
+              "description": "Defines the value which will be written to WriteRegister to reset the EC."
+            },
+            "FanDisplayName": {
+              "type": "string",
+              "description": "Fan display name",
+              "default": "\"\""
+            },
+            "TemperatureThresholds": {
+              "type": "array",
+              "description": "Defines how fast the fan runs at different temperatures",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "UpThreshold": {
+                      "$ref": "#/$defs/byte",
+                      "description": "NBFC will select the next upper threshold as soon as the temperature exceeds *UpThreshold*. in celsius"
+                    },
+                    "DownThreshold": {
+                      "$ref": "#/$defs/byte",
+                      "description": "NBFC will select the next lower threshold as soon as the temperature falls below the *DownThreshold*. in celsius"
+                    },
+                    "FanSpeed": {
+                      "$ref": "#/$defs/percentage",
+                      "description": "The fan speed in percent"
+                    }
+                  },
+                  "required": ["UpThreshold", "DownThreshold", "FanSpeed"]
+                }
+              ]
+            },
+            "FanSpeedPercentageOverrides": {
+              "type": "array",
+              "description": "Overrides the default algorithm to calculate fan speeds",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "FanSpeedPercentage": {
+                      "$ref": "#/$defs/percentage",
+                      "description": "The fan speed in percent"
+                    },
+                    "FanSpeedValue": {
+                      "$ref": "#/$defs/word",
+                      "description": "Fan fan speed value which will be written to WriteRegister"
+                    },
+                    "TargetOperation": {
+                      "type": "string",
+                      "default": "ReadWrite",
+                      "oneOf": [
+                        {
+                          "title": "Read",
+                          "description": "Value->Percentage",
+                          "enum": ["Read"]
+                        },
+                        {
+                          "title": "Write",
+                          "description": "Percentage->Value",
+                          "enum": ["Write"]
+                        },
+                        {
+                          "title": "ReadWrite",
+                          "description": "both",
+                          "enum": ["ReadWrite"]
+                        }
+                      ],
+                      "description": "Defines for which operations the speeds should be overridden:\n\n- Read: Value->Percentage\n- Write: Percentage->Value\n- ReadWrite: both"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "ReadRegister",
+            "WriteRegister",
+            "MinSpeedValue",
+            "MaxSpeedValue",
+            "IndependentReadMinMaxValues",
+            "MinSpeedValueRead",
+            "MaxSpeedValueRead",
+            "ResetRequired",
+            "FanSpeedResetValue",
+            "FanDisplayName",
+            "TemperatureThresholds",
+            "FanSpeedPercentageOverrides"
+          ]
+        }
+      ]
+    },
+    "RegisterWriteConfigurations": {
+      "type": "array",
+      "description": "Allows to write to any EC register",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "WriteMode": {
+              "$ref": "#/$defs/writeModeDef",
+              "description": "Defines how the value will be written:\n\n- And: register = register bitwise_and value\n- Or: register = register bitwise_or value\n- Set register = value\n"
+            },
+            "WriteOccasion": {
+              "type": "string",
+              "description": "Defines when the value should be written:\n\n- OnInitialization: writes the value once upon initialization (everytimee the fan control service is enabled or a config is applied)\n- OnWriteFanSpeed: writes the value everytimee the fan speed is set.\n",
+              "default": "OnInitialization",
+              "oneOf": [
+                {
+                  "title": "OnInitialization",
+                  "description": "writes the value once upon initialization (everytimee the fan control service is enabled or a config is applied)",
+                  "enum": ["OnInitialization"]
+                },
+                {
+                  "title": "OnWriteFanSpeed",
+                  "description": "writes the value everytimee the fan speed is set.",
+                  "enum": ["OnWriteFanSpeed"]
+                }
+              ]
+            },
+            "Register": {
+              "$ref": "#/$defs/byte",
+              "description": "The register which will be manipulated."
+            },
+            "Value": {
+              "$ref": "#/$defs/word",
+              "description": "The Value which will be written"
+            },
+            "ResetRequired": {
+              "type": "boolean",
+              "description": "Defines if the register should be reset before the service is shut down.",
+              "enum": [true, false],
+              "default": false
+            },
+            "ResetValue": {
+              "$ref": "#/$defs/word",
+              "description": "The value which will be written upon reset."
+            },
+            "ResetWriteMode": {
+              "$ref": "#/$defs/writeModeDef",
+              "description": "See WriteMode. Will only be applied on reset. Valid values: Set/And/Or"
+            },
+            "Description": {
+              "type": "string",
+              "description": "A byte description of what effect the RegisterWriteConfiguration will have",
+              "default": "\"\""
+            }
+          },
+          "required": [
+            "WriteMode",
+            "WriteOccasion",
+            "Register",
+            "Value",
+            "ResetRequired",
+            "ResetValue",
+            "ResetWriteMode",
+            "Description"
+          ]
+        }
+      ]
+    }
+  },
+  "required": [
+    "NotebookModel",
+    "Author",
+    "EcPollInterval",
+    "ReadWriteWords",
+    "CriticalTemperature",
+    "FanConfigurations",
+    "RegisterWriteConfigurations"
+  ],
+  "$defs": {
+    "writeModeDef": {
+      "type": "string",
+      "default": "Set",
+      "oneOf": [
+        {
+          "title": "And",
+          "description": "register = register bitwise_and value",
+          "enum": ["And"]
+        },
+        {
+          "title": "Or",
+          "description": "register = register bitwise_or value",
+          "enum": ["Or"]
+        },
+        {
+          "title": "Set",
+          "description": "register = value",
+          "enum": ["Set"]
+        }
+      ]
+    },
+    "byte": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 255
+    },
+    "percentage": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 100.0
+    },
+    "word": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 65535
+    }
+  }
+}


### PR DESCRIPTION
Hi,

this pull request adds a JSON schema file for nbfc-linux config files. With such a file, it's possible to edit/write config files with auto-completion and validation by e.g.  [json-lsp]( https://github.com/microsoft/vscode-json-languageservice) and, perhaps, other third-party tools.
 
As an example, this is my json-lsp config in neovim, that enables this support:
`    "jsonls": {
      "json.schemaDownload.enable": true,
      "json.format.enable": true,
      "json.validate.enable": true,
      "json.schemas": [
        {
          "description": "nbfc-linux configuration file",
          "fileMatch": ["config.json"],
          "url": "file:///home/<user>/.config/nvim/schema/FanControlConfigV3-v1.0.0-schema.json"
        }
      ]
    }
`

Kind regards,
Stefan