### PR TITLE
Fixed Lenovo Yoga Slim7 configs

### DIFF
--- a/share/nbfc/configs/Lenovo Yoga Slim7.json
+++ b/share/nbfc/configs/Lenovo Yoga Slim7.json
@@ -20,7 +20,7 @@
 	   "FanSpeed": 0.0
 	  },
 	  {
-	   "UpThreshold": 80,
+	   "UpThreshold": 85,
 	   "DownThreshold": 85,
 	   "FanSpeed": 15.0
 	  },

--- a/xml/Lenovo Yoga Slim7.xml
+++ b/xml/Lenovo Yoga Slim7.xml
@@ -21,7 +21,7 @@
           <FanSpeed>0</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
-          <UpThreshold>80</UpThreshold>
+          <UpThreshold>85</UpThreshold>
           <DownThreshold>85</DownThreshold>
           <FanSpeed>15</FanSpeed>
         </TemperatureThreshold>


### PR DESCRIPTION
The current config for the Lenovo Yoga Slim7 has an error, where there are two identical `UpThreashold` values. This request fixes this.