### PR TITLE
Add HP 15s-eq3xxx config

### DIFF
--- a/share/nbfc/configs/HP Laptop 15s-eq3xxx.json
+++ b/share/nbfc/configs/HP Laptop 15s-eq3xxx.json
@@ -1,0 +1,68 @@
+{
+  "NotebookModel": "HP Laptop 15s-eq3xxx",
+  "Author": "Maru",
+  "EcPollInterval": 100,
+  "ReadWriteWords": false,
+  "CriticalTemperature": 85,
+  "CriticalTemperatureOffset": 5,
+  "FanConfigurations": [
+    {
+      "ReadRegister": 46,
+      "WriteRegister": 44,
+      "MinSpeedValue": 20,
+      "MaxSpeedValue": 100,
+      "IndependentReadMinMaxValues": false,
+      "MinSpeedValueRead": 0,
+      "MaxSpeedValueRead": 0,
+      "ResetRequired": false,
+      "FanSpeedResetValue": 255,
+      "FanDisplayName": "CPU Fan",
+      "TemperatureThresholds": [
+	{
+          "UpThreshold": 50,
+          "DownThreshold": 40,
+          "FanSpeed": 0
+        },
+        {
+          "UpThreshold": 60,
+          "DownThreshold": 50,
+          "FanSpeed": 30
+        },
+	{
+          "UpThreshold": 70,
+          "DownThreshold": 60,
+          "FanSpeed": 40
+        },
+        {
+          "UpThreshold": 80,
+          "DownThreshold": 70,
+          "FanSpeed": 60
+        },
+	{
+	  "UpThreshold": 85,
+	  "DownThreshold": 80,
+	  "FanSpeed": 90
+	}
+      ],
+      "FanSpeedPercentageOverrides": [
+        {
+          "FanSpeedPercentage": 100.0,
+          "FanSpeedValue": 100,
+          "TargetOperation": "ReadWrite"
+        }
+      ]
+    }
+  ],
+  "RegisterWriteConfigurations": [
+    {
+      "WriteMode": "Set",
+      "WriteOccasion": "OnInitialization",
+      "Register": 44,
+      "Value": 20,
+      "ResetRequired": true,
+      "ResetValue": 255,
+      "ResetWriteMode": "Set",
+      "Description": "Override"
+    }
+  ]
+}


### PR DESCRIPTION
We are using register '46' for read to prevent triggering battery error after some time that requires BIOS reset.