### PR TITLE
Add Acer Aspire A315-57G-74A3 config

### DIFF
--- a/share/nbfc/configs/Acer Aspire A315-57G-74A3.json
+++ b/share/nbfc/configs/Acer Aspire A315-57G-74A3.json
@@ -1,0 +1,62 @@
+{
+ "NotebookModel": "Acer Aspire A315-55G",
+ "Author": "Nj0be",
+ "EcPollInterval": 150,
+ "ReadWriteWords": false,
+ "CriticalTemperature": 95,
+ "FanConfigurations": [
+	{
+	 "ReadRegister": 85,
+	 "WriteRegister": 85,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 10,
+	 "TemperatureThresholds": [
+      	  {
+	   "UpThreshold": 55,
+	   "DownThreshold": 0,
+	   "FanSpeed": 20
+	  },
+	  {
+	   "UpThreshold": 60,
+	   "DownThreshold": 50,
+	   "FanSpeed": 30
+	  },
+	  {
+	   "UpThreshold": 65,
+	   "DownThreshold": 55,
+	   "FanSpeed": 40
+	  },
+	  {
+	   "UpThreshold": 70,
+	   "DownThreshold": 60,
+	   "FanSpeed": 50
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 65,
+	   "FanSpeed":60
+	  },
+	  {
+	   "UpThreshold": 80,
+	   "DownThreshold": 70,
+	   "FanSpeed": 70
+	  },
+	  {
+	   "UpThreshold": 89,
+	   "DownThreshold": 75,
+	   "FanSpeed": 80
+	  },
+	  {
+	   "UpThreshold": 92,
+	   "DownThreshold": 87,
+	   "FanSpeed": 90
+	  },
+	  {
+	   "UpThreshold": 95,
+	   "DownThreshold": 90,
+	   "FanSpeed": 100
+	  }
+	 ]
+	}
+ ]
+}


### PR DESCRIPTION
Created config for Acer Aspire A315-57G-74A3.
The last two fan speeds are set to such high temperatures because they reduce the clock speed.
Additionally, I didn’t set a specific temperature for the fan to turn off because the BIOS continuously overwrites the fan speed settings and tries to activate the fan. By default, the fan won’t shut off unless the temperature drops to extremely low levels, which are unattainable under normal conditions.
As a result, if we configure the fan to turn off, it remains off most of the time but occasionally powers on for a fraction of a second, repeatedly starting and stopping (which I believe is harmful).