### PR TITLE
Add configuration for Acer Nitro AN515-47

### DIFF
--- a/share/nbfc/configs/Acer Nitro AN515-47.json
+++ b/share/nbfc/configs/Acer Nitro AN515-47.json
@@ -1,0 +1,129 @@
+{
+ "NotebookModel": "Acer Nitro AN515-47",
+ "Author": "Josesk Volpe",
+ "EcPollInterval": 3000,
+ "ReadWriteWords": true,
+ "CriticalTemperature": 93,
+ "FanConfigurations": [
+	{
+	 "ReadRegister": 19,
+	 "WriteRegister": 55,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 100,
+	 "IndependentReadMinMaxValues": true,
+	 "MinSpeedValueRead": 0,
+	 "MaxSpeedValueRead": 7317,
+	 "ResetRequired": true,
+	 "FanSpeedResetValue": 0,
+	 "FanDisplayName": "CPU fan",
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 40,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+		"UpThreshold": 60,
+		"DownThreshold": 39,
+		"FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 80,
+	   "DownThreshold": 55,
+	   "FanSpeed": 30.0
+	  },
+	  {
+		"UpThreshold": 89,
+		"DownThreshold": 73,
+		"FanSpeed": 70.0
+	  },
+	  {
+		"UpThreshold": 92,
+		"DownThreshold": 80,
+		"FanSpeed": 80.0
+	  },
+	  {
+	   "UpThreshold": 93,
+	   "DownThreshold": 87,
+	   "FanSpeed": 100.0
+	  }
+	 ],
+	 "FanSpeedPercentageOverrides": []
+	},
+	{
+	 "ReadRegister": 21,
+	 "WriteRegister": 58,
+	 "MinSpeedValue": 0,
+	 "MaxSpeedValue": 100,
+	 "IndependentReadMinMaxValues": true,
+	 "MinSpeedValueRead": 0,
+	 "MaxSpeedValueRead": 7317,
+	 "ResetRequired": true,
+	 "FanSpeedResetValue": 0,
+	 "FanDisplayName": "GPU fan",
+	 "TemperatureThresholds": [
+	  {
+	   "UpThreshold": 40,
+	   "DownThreshold": 0,
+	   "FanSpeed": 0.0
+	  },
+	  {
+		"UpThreshold": 60,
+		"DownThreshold": 40,
+		"FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 75,
+	   "DownThreshold": 54,
+	   "FanSpeed": 30.0
+	  },
+	  {
+	    "UpThreshold": 80,
+	    "DownThreshold": 65,
+	    "FanSpeed": 52.0
+	  }
+	  {
+		"UpThreshold": 89,
+		"DownThreshold": 70,
+		"FanSpeed": 80.0
+	  },
+	  {
+	    "UpThreshold": 90,
+	    "DownThreshold": 87,
+	    "FanSpeed": 100.0
+	  }
+	 ],
+	 "FanSpeedPercentageOverrides": []
+	}
+ ],
+ "RegisterWriteConfigurations": [
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnInitialization",
+	 "Register": 34,
+	 "Value": 12,
+	 "ResetRequired": true,
+	 "ResetValue": 4,
+	 "ResetWriteMode": "Set",
+	 "Description": "CPU fan manual mode"
+	},
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnInitialization",
+	 "Register": 33,
+	 "Value": 48,
+	 "ResetRequired": true,
+	 "ResetValue": 16,
+	 "ResetWriteMode": "Set",
+	 "Description": "GPU fan manual mode"
+	},
+	{
+	 "WriteMode": "Set",
+	 "WriteOccasion": "OnInitialization",
+	 "Register": 3,
+	 "Value":  17,
+	 "ResetRequired": false,
+	 "Description": "Enables fan control in Linux for some reason"
+	}
+ ]
+}

--- a/share/nbfc/configs/Acer Nitro AN515-47.json
+++ b/share/nbfc/configs/Acer Nitro AN515-47.json
@@ -23,24 +23,35 @@
 	   "FanSpeed": 0.0
 	  },
 	  {
-		"UpThreshold": 60,
-		"DownThreshold": 39,
-		"FanSpeed": 10.0
+	   "UpThreshold": 70,
+	   "DownThreshold": 65,
+	   "FanSpeed": 5.0
+
 	  },
 	  {
 	   "UpThreshold": 78,
-	   "DownThreshold": 55,
+	   "DownThreshold": 69,
+	   "FanSpeed": 10.0
+	  },
+	  {
+	   "UpThreshold": 80,
+	   "DownThreshold": 75,
 	   "FanSpeed": 30.0
 	  },
 	  {
-		"UpThreshold": 85,
-		"DownThreshold": 69,
-		"FanSpeed": 70.0
+	   "UpThreshold": 85,
+	   "DownThreshold": 75,
+	   "FanSpeed": 70.0
 	  },
 	  {
-		"UpThreshold": 90,
-		"DownThreshold": 78,
-		"FanSpeed": 80.0
+	   "UpThreshold": 89,
+	   "DownThreshold": 78,
+	   "FanSpeed": 80.0
+	  },
+	  {
+	   "UpThreshold": 90,
+	   "DownThreshold": 85,
+	   "FanSpeed": 100.0
 	  }
 	 ],
 	 "FanSpeedPercentageOverrides": []
@@ -58,29 +69,34 @@
 	 "FanDisplayName": "GPU fan",
 	 "TemperatureThresholds": [
 	  {
-	   "UpThreshold": 45,
+	   "UpThreshold": 52,
 	   "DownThreshold": 0,
 	   "FanSpeed": 0.0
 	  },
 	  {
-		"UpThreshold": 50,
-		"DownThreshold": 40,
-		"FanSpeed": 10.0
+		"UpThreshold": 60,
+		"DownThreshold": 48,
+		"FanSpeed": 8.0
 	  },
 	  {
 	   "UpThreshold": 73,
-	   "DownThreshold": 48,
+	   "DownThreshold": 55,
 	   "FanSpeed": 30.0
 	  },
 	  {
 	    "UpThreshold": 80,
-	    "DownThreshold": 65,
+	    "DownThreshold": 69,
 	    "FanSpeed": 52.0
 	  },
 	  {
-		"UpThreshold": 90,
+		"UpThreshold": 89,
 		"DownThreshold": 70,
 		"FanSpeed": 80.0
+	  },
+	  {
+	   "UpThreshold": 90,
+	   "DownThreshold": 83,
+	   "FanSpeed": 100.0
 	  }
 	 ],
 	 "FanSpeedPercentageOverrides": []

--- a/share/nbfc/configs/Acer Nitro AN515-47.json
+++ b/share/nbfc/configs/Acer Nitro AN515-47.json
@@ -3,7 +3,7 @@
  "Author": "Josesk Volpe",
  "EcPollInterval": 3000,
  "ReadWriteWords": true,
- "CriticalTemperature": 93,
+ "CriticalTemperature": 90,
  "FanConfigurations": [
 	{
 	 "ReadRegister": 19,
@@ -28,24 +28,19 @@
 		"FanSpeed": 10.0
 	  },
 	  {
-	   "UpThreshold": 80,
+	   "UpThreshold": 78,
 	   "DownThreshold": 55,
 	   "FanSpeed": 30.0
 	  },
 	  {
-		"UpThreshold": 89,
-		"DownThreshold": 73,
+		"UpThreshold": 85,
+		"DownThreshold": 69,
 		"FanSpeed": 70.0
 	  },
 	  {
-		"UpThreshold": 92,
-		"DownThreshold": 80,
+		"UpThreshold": 90,
+		"DownThreshold": 78,
 		"FanSpeed": 80.0
-	  },
-	  {
-	   "UpThreshold": 93,
-	   "DownThreshold": 87,
-	   "FanSpeed": 100.0
 	  }
 	 ],
 	 "FanSpeedPercentageOverrides": []
@@ -63,34 +58,29 @@
 	 "FanDisplayName": "GPU fan",
 	 "TemperatureThresholds": [
 	  {
-	   "UpThreshold": 40,
+	   "UpThreshold": 45,
 	   "DownThreshold": 0,
 	   "FanSpeed": 0.0
 	  },
 	  {
-		"UpThreshold": 60,
+		"UpThreshold": 50,
 		"DownThreshold": 40,
 		"FanSpeed": 10.0
 	  },
 	  {
-	   "UpThreshold": 75,
-	   "DownThreshold": 54,
+	   "UpThreshold": 73,
+	   "DownThreshold": 48,
 	   "FanSpeed": 30.0
 	  },
 	  {
 	    "UpThreshold": 80,
 	    "DownThreshold": 65,
 	    "FanSpeed": 52.0
-	  }
-	  {
-		"UpThreshold": 89,
-		"DownThreshold": 70,
-		"FanSpeed": 80.0
 	  },
 	  {
-	    "UpThreshold": 90,
-	    "DownThreshold": 87,
-	    "FanSpeed": 100.0
+		"UpThreshold": 90,
+		"DownThreshold": 70,
+		"FanSpeed": 80.0
 	  }
 	 ],
 	 "FanSpeedPercentageOverrides": []


### PR DESCRIPTION
Laptop has 2 coolers and may reach 7317 RPMs maximum. No CoolerBoost. It's required to write 0x11 to address 0x03 in EC memory to be able to control fans in Linux. The laptop also has 3 energy operation modes: Standard, Quiet and Performance.

Tested this settings in Minecraft, 5 hours long gameplay, with heavy shaders and 90 mods. GPU reaches 78ºC at maximum and CPU sometimes 95ºC, with average of about 74ºC for GPU and 78ºC for CPU, with coolers usually being at 80% most time. Weather at the day was 31ºC.
CPU fans usually gets on 10% and 30% in basic usage with 70% speed sometimes for a short period.

EC addresses:
```
GPU Fan Speed Write: 0x3A (Max 0x64)
GPU Fan Speed Read: 0x15 (16-bit)
CPU Fan Speed Write: 0x37 (Max 0x64)
CPU Fan Speed Read: 0x13 (16-bit)

GPU auto mode: 0x21 (0x10 Auto 0x30 Manual)
CPU auto mode: 0x22 (0x04 Auto 0x0C Manual)

80% charge limit: 0xDD (0x00 Off 0x80 On)
Keyboard light automatic turn off: 0x06 (0x00 Disabled 0x1E Enabled)
Energy mode: 0x2C (0x01 Standard 0x00 Quiet 0x04 Performance)

Microphone key LED: 0x30 (0x10 On 0x00 Off) - Read-only, seems to be managed by BIOS. Only the 4th bit is used.
```

Thread: https://forums.opensuse.org/t/fan-control-in-acer-nitro-5-an515-47-nbfc-linux/178749