### PR TITLE
Fix mistake in NixOS docs

### DIFF
--- a/nixos-installation-new.md
+++ b/nixos-installation-new.md
@@ -66,7 +66,7 @@ in {
     # if you are on stable uncomment the next line
     #  script = "${inputs.nbfc-linux.packages.x86_64-linux.default}/${command}";
     # if you are on unstable uncomment the next line
-    #script = "${pkgs.nbfc-linux.packages}/${command}";
+    #script = "${pkgs.nbfc-linux}/${command}";
    
     wantedBy = ["multi-user.target"];
   };


### PR DESCRIPTION
Just tried to install it using my own docs and realised i made a mistake 🤦‍♂️

it should be 
```
 script = "${pkgs.nbfc-linux}/${command}";
```
and not
```
 script = "${pkgs.nbfc-linux.packages}/${command}";
```