### PR TITLE
Improve compilation debugging and remove confdir hardcoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ version     = 0.2.9
 PREFIX      = /usr
 
 bindir			= $(PREFIX)/bin
-confdir 		= $(PREFIX)/etc
+confdir 		= /etc
 datadir			= $(PREFIX)/share
 sysddir 		= $(PREFIX)/lib/systemd/system
 mandir 			= $(PREFIX)/share/man

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ version     = 0.2.9
 PREFIX      = /usr
 
 bindir			= $(PREFIX)/bin
-confdir 		= /etc
+confdir 		= $(PREFIX)/etc
 datadir			= $(PREFIX)/share
 sysddir 		= $(PREFIX)/lib/systemd/system
 mandir 			= $(PREFIX)/share/man
@@ -119,7 +119,7 @@ etc/init.d/nbfc_service.systemv: etc/init.d/nbfc_service.systemv.in
 install-configs:
 	# /usr/local/etc/nbfc
 	mkdir -p $(DESTDIR)$(confdir)/nbfc
-	
+
 	# /usr/local/share/nbfc/configs
 	mkdir -p $(DESTDIR)$(datadir)/nbfc/configs
 	cp share/nbfc/model_support.json $(DESTDIR)$(datadir)/nbfc
@@ -166,37 +166,37 @@ uninstall:
 	rm -f $(DESTDIR)$(bindir)/nbfc_service
 	rm -f $(DESTDIR)$(bindir)/ec_probe
 	rm -f $(DESTDIR)$(bindir)/nbfc-qt
-	
+
 	# /usr/local/lib/systemd/system
 	rm -f $(DESTDIR)$(sysddir)/nbfc_service.service
-	
+
 	# /usr/local/etc/init.d
 	rm -f $(DESTDIR)$(orcdir)/nbfc_service
-	
+
 	# /usr/local/etc/init.d
 	rm -f $(DESTDIR)$(systemvdir)/nbfc_service
-	
+
 	# /usr/local/share/nbfc/configs
 	rm -rf $(DESTDIR)$(datadir)/nbfc
-	
+
 	# /usr/local/etc/nbfc
 	rm -rf $(DESTDIR)$(confdir)/nbfc
-	
+
 	# Documentation
 	rm -f $(DESTDIR)$(man1dir)/ec_probe.1
 	rm -f $(DESTDIR)$(man1dir)/nbfc.1
 	rm -f $(DESTDIR)$(man1dir)/nbfc_service.1
 	rm -f $(DESTDIR)$(man5dir)/nbfc_service.json.5
-	
+
 	# Completion
 	rm -f $(DESTDIR)$(datadir)/zsh/site-functions/_nbfc
 	rm -f $(DESTDIR)$(datadir)/zsh/site-functions/_nbfc_service
 	rm -f $(DESTDIR)$(datadir)/zsh/site-functions/_ec_probe
-	
+
 	rm -f $(DESTDIR)$(datadir)/bash-completion/completions/nbfc
 	rm -f $(DESTDIR)$(datadir)/bash-completion/completions/nbfc_service
 	rm -f $(DESTDIR)$(datadir)/bash-completion/completions/ec_probe
-	 
+
 	rm -f $(DESTDIR)$(datadir)/fish/completions/nbfc.fish
 	rm -f $(DESTDIR)$(datadir)/fish/completions/nbfc_service.fish
 	rm -f $(DESTDIR)$(datadir)/fish/completions/ec_probe.fish
@@ -287,7 +287,7 @@ doc: doc/ec_probe.1 doc/nbfc.1 doc/nbfc_service.1 doc/nbfc_service.json.5
 	pandoc -f man -t markdown doc/nbfc.1 							> doc/nbfc.1.md
 	pandoc -f man -t markdown doc/nbfc_service.1 			> doc/nbfc_service.1.md
 	pandoc -f man -t markdown doc/nbfc_service.json.5 > doc/nbfc_service.json.5.md
-	
+
 	pandoc -f man -t html doc/ec_probe.1 					> doc/ec_probe.1.html
 	pandoc -f man -t html doc/nbfc.1 							> doc/nbfc.1.html
 	pandoc -f man -t html doc/nbfc_service.1 			> doc/nbfc_service.1.html

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-which autoreconf &>/dev/null || {
-  echo "autoreconf not found. please install the 'autoconf' package"
+type autoreconf >/dev/null || {
+  echo "autoreconf not found, please install the 'autoconf' package" >&2
   exit 1
 }
 autoreconf --force --install

--- a/share/nbfc/configs/GPD Win Mini.json
+++ b/share/nbfc/configs/GPD Win Mini.json
@@ -1,0 +1,52 @@
+{
+  "NotebookModel": "GPD Win Mini",
+  "Author": "Justin Weiss",
+  "EcPollInterval": 5000,
+  "ReadWriteWords": false,
+  "CriticalTemperature": 85,
+  "FanConfigurations": [
+    {
+      "ReadRegister": 122,
+      "WriteRegister": 122,
+      "MinSpeedValue": 1,
+      "MaxSpeedValue": 244,
+      "ResetRequired": true,
+      "FanSpeedResetValue": 0,
+      "FanDisplayName": "Fan",
+      "TemperatureThresholds": [
+        {
+          "UpThreshold": 30,
+          "DownThreshold": 0,
+          "FanSpeed": 0.0
+        },
+        {
+          "UpThreshold": 45,
+          "DownThreshold": 25,
+          "FanSpeed": 30.0
+        },
+        {
+          "UpThreshold": 60,
+          "DownThreshold": 40,
+          "FanSpeed": 40.0
+        },
+        {
+          "UpThreshold": 70,
+          "DownThreshold": 50,
+          "FanSpeed": 60.0
+        },
+        {
+          "UpThreshold": 80,
+          "DownThreshold": 65,
+          "FanSpeed": 80.0
+        },
+        {
+          "UpThreshold": 85,
+          "DownThreshold": 75,
+          "FanSpeed": 100.0
+        }
+      ],
+      "FanSpeedPercentageOverrides": []
+    }
+  ],
+  "RegisterWriteConfigurations": []
+}


### PR DESCRIPTION
- Replaced `which autoreconf &>/dev/null` with `type autoreconf >/dev/null` to remove `which` dependency, `type` being readily available on more build systems.
- Replaced stderr silencing with stdout silencing. Having more debugging information would have helped me understand that what blocked packaging it for Guix was just the missing `which` dependency in the build environment, I suppose more debugging could be useful to others.
- Changed `confdir` being hardcoded to `/etc` in the Makefile, which prevents installation on immutable systems. This was also probably in part causing #191 while using a `PREFIX` in a writable folder would allow working around this (but the recent support of absolute paths to configurations in 3c59e3347a68f218760e834f45e9593d7318c393 is still great).

I don't know how critical is the third change. I think hardcoding `confdir` is not ideal but maybe my change causes other issues?