### PR TITLE
Added config for HP Victus 15-fb0xxx

### DIFF
--- a/share/nbfc/configs/HP Victus 15-fb0xxx.json
+++ b/share/nbfc/configs/HP Victus 15-fb0xxx.json
@@ -1,0 +1,123 @@
+{
+    "LegacyTemperatureThresholdsBehaviour": true,
+    "NotebookModel": "HP Victus 15-fb0xxx",
+    "Author": "subhojit131",
+    "EcPollInterval": 1000,
+    "ReadWriteWords": false,
+    "CriticalTemperature": 85,
+    "FanConfigurations": [
+       {
+        "ReadRegister": 179,
+        "WriteRegister": 45,
+        "MinSpeedValue": 0,
+        "MaxSpeedValue": 100,
+        "IndependentReadMinMaxValues": true,
+        "MinSpeedValueRead": 0,
+        "MaxSpeedValueRead": 32,
+        "ResetRequired": true,
+        "FanSpeedResetValue": 255,
+        "FanDisplayName": "CPU Fan",
+        "TemperatureThresholds": [
+         {
+          "UpThreshold": 0,
+          "DownThreshold": 0,
+          "FanSpeed": 0.0
+         },
+         {
+          "UpThreshold": 55,
+          "DownThreshold": 45,
+          "FanSpeed": 10.0
+         },
+         {
+          "UpThreshold": 63,
+          "DownThreshold": 54,
+          "FanSpeed": 20.0
+         },
+         {
+          "UpThreshold": 68,
+          "DownThreshold": 62,
+          "FanSpeed": 50.0
+         },
+         {
+          "UpThreshold": 71,
+          "DownThreshold": 67,
+          "FanSpeed": 70.0
+         },
+         {
+          "UpThreshold": 79,
+          "DownThreshold": 70,
+          "FanSpeed": 80.0
+         },
+         {
+          "UpThreshold": 82,
+          "DownThreshold": 78,
+          "FanSpeed": 100.0
+         }
+        ],
+        "FanSpeedPercentageOverrides": [
+         {
+          "FanSpeedPercentage": 0.0,
+          "FanSpeedValue": 255,
+          "TargetOperation": "Write"
+         }
+        ]
+       },
+       {
+        "ReadRegister": 177,
+        "WriteRegister": 44,
+        "MinSpeedValue": 0,
+        "MaxSpeedValue": 100,
+        "IndependentReadMinMaxValues": true,
+        "MinSpeedValueRead": 0,
+        "MaxSpeedValueRead": 33,
+        "ResetRequired": true,
+        "FanSpeedResetValue": 255,
+        "FanDisplayName": "GPU fan",
+        "TemperatureThresholds": [
+         {
+          "UpThreshold": 0,
+          "DownThreshold": 0,
+          "FanSpeed": 0.0
+         },
+         {
+          "UpThreshold": 55,
+          "DownThreshold": 45,
+          "FanSpeed": 10.0
+         },
+         {
+          "UpThreshold": 63,
+          "DownThreshold": 54,
+          "FanSpeed": 20.0
+         },
+         {
+          "UpThreshold": 68,
+          "DownThreshold": 62,
+          "FanSpeed": 50.0
+         },
+         {
+          "UpThreshold": 71,
+          "DownThreshold": 67,
+          "FanSpeed": 70.0
+         },
+         {
+          "UpThreshold": 79,
+          "DownThreshold": 70,
+          "FanSpeed": 80.0
+         },
+         {
+          "UpThreshold": 82,
+          "DownThreshold": 78,
+          "FanSpeed": 100.0
+         }
+        ],
+        "FanSpeedPercentageOverrides": [
+         {
+          "FanSpeedPercentage": 0.0,
+          "FanSpeedValue": 255,
+          "TargetOperation": "Write"
+         }
+        ]
+       }
+    ],
+    "RegisterWriteConfigurations": []
+   }


### PR DESCRIPTION
This pull request adds a custom configuration for the HP Victus 15-fb0xxx laptop (with AMD Ryzen 5 5600H and Radeon RX 6500M), tested with nbfc-linux