### PR TITLE
Added configuration for Acer Aspire Lite AL15-41

### DIFF
--- a/share/nbfc/configs/Acer Aspire Lite AL15-41.json
+++ b/share/nbfc/configs/Acer Aspire Lite AL15-41.json
@@ -1,0 +1,40 @@
+{
+    "NotebookModel": "Acer Aspire Lite AL15-41",
+    "Author": "OnlineLearningTutorials",
+    "EcPollInterval": 1000,
+    "FanConfigurations": [
+    {
+        "ReadRegister": 209,
+        "WriteRegister": 231,
+        "MinSpeedValue": 0,
+        "MaxSpeedValue": 100,
+        "ResetRequired": true,
+        "FanDisplayName": "CPU fan",
+        "TemperatureThresholds": [
+        {
+            "UpThreshold": 0,
+            "DownThreshold": 0,
+            "FanSpeed": 0.0
+        },
+        {
+            "UpThreshold": 50,
+            "DownThreshold": 40,
+            "FanSpeed": 30.0
+        },
+        {
+            "UpThreshold": 60,
+            "DownThreshold": 45,
+            "FanSpeed": 50.0
+        },
+        {
+            "UpThreshold": 70,
+            "DownThreshold": 55,
+            "FanSpeed": 70.0
+        },
+        {
+            "UpThreshold": 80,
+            "DownThreshold": 65,
+            "FanSpeed": 100.0
+        }]
+    }]
+}


### PR DESCRIPTION
I made a configuration config for Acer Aspire Lite AL15-41, which is working fine with nbfc-qt. 
<img width="461" height="457" alt="Screenshot From 2025-09-22 15-07-33" src="https://github.com/user-attachments/assets/6f388556-392b-45f6-a10b-49ccb7524e0f" />

However I am proficient in it. I don't know maximum speed is 100 or 255. And many other configuration option I removed those not understand. Please feel free of any improvement if you find.