### PR TITLE
Add configuration for HP Pavilion Gaming Laptop 15-dk0xxx

### DIFF
--- a/share/nbfc/configs/HP Pavilion Gaming Laptop 15-dk0xxx.json
+++ b/share/nbfc/configs/HP Pavilion Gaming Laptop 15-dk0xxx.json
@@ -1,6 +1,6 @@
 {
  "LegacyTemperatureThresholdsBehaviour": true,
- "NotebookModel": "HP Pavilion Gaming 15-dk0xxx",
+ "NotebookModel": "HP Pavilion Gaming Laptop 15-dk0xxx",
  "Author": "DemonKingSwarn",
  "EcPollInterval": 1000,
  "ReadWriteWords": false,


### PR DESCRIPTION
Config for HP Pavilion Gaming Laptop 15-dk0xxx.

Uses same registers like HP Pavilion Gaming Laptop 15-ec0xxx.