### PR TITLE
Update config for HP Victus 15-fb0xxxx

### DIFF
--- a/share/nbfc/configs/HP Victus 15-fb0xxx.json
+++ b/share/nbfc/configs/HP Victus 15-fb0xxx.json
@@ -55,13 +55,6 @@
          "DownThreshold": 79,
          "FanSpeed": 100.0
         }
-       ],
-       "FanSpeedPercentageOverrides": [
-        {
-         "FanSpeedPercentage": 0.0,
-         "FanSpeedValue": 255,
-         "TargetOperation": "Write"
-        }
        ]
       },
       {
@@ -113,13 +106,6 @@
             "DownThreshold": 79,
             "FanSpeed": 100.0
            }
-       ],
-       "FanSpeedPercentageOverrides": [
-        {
-         "FanSpeedPercentage": 0.0,
-         "FanSpeedValue": 255,
-         "TargetOperation": "Write"
-        }
        ]
       }
    ],


### PR DESCRIPTION
Removes the 255 `FanSpeedPercentageOverrides`. Rest of config stays the same.

On my machine (Victus 15-fb0010nt) the 255 value will cause the fans to constantly spin up and down and up and down... Setting it to 0 (removing override) will truly turn them off. Of course this requires "Fan Always On" disabled in HP BIOS.

Would appreciate testing from other Victus 15-fb models.