### PR TITLE
Add Asus Zenbook UX510UWK fan config

### DIFF
--- a/share/nbfc/configs/Asus Zenbook UX510UWK.json
+++ b/share/nbfc/configs/Asus Zenbook UX510UWK.json
@@ -1,0 +1,43 @@
+{
+  "LegacyTemperatureThresholdsBehaviour": true,
+  "NotebookModel": "Asus Zenbook UX510UWK",
+  "Author": "fanilo",
+  "EcPollInterval": 300,
+  "ReadWriteWords": false,
+  "CriticalTemperature": 90,
+  "FanConfigurations": [
+    {
+      "ReadRegister": 151,
+      "WriteRegister": 151,
+      "MinSpeedValue": 0,
+      "MaxSpeedValue": 8,
+      "IndependentReadMinMaxValues": false,
+      "MinSpeedValueRead": 0,
+      "MaxSpeedValueRead": 0,
+      "ResetRequired": true,
+      "FanSpeedResetValue": 9,
+      "FanDisplayName": "CPU Fan",
+      "TemperatureThresholds": [
+        { "UpThreshold": 0,  "DownThreshold": 0,  "FanSpeed": 0.0 },
+        { "UpThreshold": 55, "DownThreshold": 48, "FanSpeed": 12.5 },
+        { "UpThreshold": 62, "DownThreshold": 55, "FanSpeed": 25.0 },
+        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 37.5 },
+        { "UpThreshold": 75, "DownThreshold": 72, "FanSpeed": 50.0 },
+        { "UpThreshold": 80, "DownThreshold": 77, "FanSpeed": 75.0 },
+        { "UpThreshold": 85, "DownThreshold": 82, "FanSpeed": 100.0 }
+      ]
+    }
+  ],
+  "RegisterWriteConfigurations": [
+    {
+      "WriteMode": "Set",
+      "WriteOccasion": "OnWriteFanSpeed",
+      "Register": 160,
+      "Value": 10,
+      "ResetRequired": true,
+      "ResetValue": 10,
+      "ResetWriteMode": "Set",
+      "Description": "Set manual fan control mode (0xA0)"
+    }
+  ]
+}


### PR DESCRIPTION
## New device config: ASUS Zenbook UX510UWK

**Hardware:** ASUS UX510UWK (i7-7500U, GTX 960M, dual fan)
**Kernel:** 6.1.0-44-amd64 (Debian 12 Bookworm)
**EC access:** dev_port

### Fan 1 (CPU) — this config
- Register: 0x97 (decimal 151)
- Speed range: 0–8 (0=off, 8=max, 9=auto reset)
- Based on UX530U profile, tested and working
- RegisterWriteConfiguration at 0xA0 for manual mode

### Fan 2 (GPU) — NOT included (requires acpi_call)
The GPU fan uses extended EC register WRAM(0xF922) with bit 0x40 toggle.
This is beyond nbfc's standard EC range (0x00-0xFF).
Standalone tool: https://github.com/nhilo94/asus-ux510-fan2

### Testing
- Tested on Debian 12 Bookworm, kernel 6.1.0-44-amd64
- Fan 1 responds correctly to all speed values 0-8
- Temperature thresholds tuned for daily use