### PR TITLE
Add config for Acer Nitro ANV15-52

### DIFF
--- a/share/nbfc/configs/Acer Nitro ANV15-52.json
+++ b/share/nbfc/configs/Acer Nitro ANV15-52.json
@@ -1,0 +1,56 @@
+{
+  "LegacyTemperatureThresholdsBehaviour": true,
+  "NotebookModel": "Acer Nitro ANV15-52",
+  "Author": "dk3775",
+  "EcPollInterval": 3000,
+  "ReadWriteWords": false,
+  "CriticalTemperature": 95,
+  "FanConfigurations": [
+    {
+      "ReadRegister": 92,
+      "WriteRegister": 73,
+      "MinSpeedValue": 0,
+      "MaxSpeedValue": 100,
+      "ResetRequired": false,
+      "FanSpeedResetValue": 0,
+      "TemperatureThresholds": [
+        { "UpThreshold": 0,  "DownThreshold": 0,  "FanSpeed": 0.0   },
+        { "UpThreshold": 35, "DownThreshold": 30, "FanSpeed": 0.0   },
+        { "UpThreshold": 45, "DownThreshold": 40, "FanSpeed": 30.0  },
+        { "UpThreshold": 55, "DownThreshold": 50, "FanSpeed": 50.0  },
+        { "UpThreshold": 65, "DownThreshold": 60, "FanSpeed": 70.0  },
+        { "UpThreshold": 75, "DownThreshold": 70, "FanSpeed": 90.0  },
+        { "UpThreshold": 85, "DownThreshold": 80, "FanSpeed": 100.0 }
+      ]
+    },
+    {
+      "ReadRegister": 106,
+      "WriteRegister": 74,
+      "MinSpeedValue": 0,
+      "MaxSpeedValue": 100,
+      "ResetRequired": false,
+      "FanSpeedResetValue": 0,
+      "TemperatureThresholds": [
+        { "UpThreshold": 0,  "DownThreshold": 0,  "FanSpeed": 0.0   },
+        { "UpThreshold": 35, "DownThreshold": 30, "FanSpeed": 0.0   },
+        { "UpThreshold": 45, "DownThreshold": 40, "FanSpeed": 30.0  },
+        { "UpThreshold": 55, "DownThreshold": 50, "FanSpeed": 50.0  },
+        { "UpThreshold": 65, "DownThreshold": 60, "FanSpeed": 70.0  },
+        { "UpThreshold": 75, "DownThreshold": 70, "FanSpeed": 90.0  },
+        { "UpThreshold": 85, "DownThreshold": 80, "FanSpeed": 100.0 }
+      ]
+    }
+  ],
+  "RegisterWriteConfigurations": [
+    {
+      "WriteMode": "Set",
+      "WriteOccasion": "OnInitialization",
+      "Register": 190,
+      "Value": 0,
+      "ResetRequired": true,
+      "ResetValue": 224,
+      "ResetWriteMode": "Set",
+      "Description": "Set EC to manual/enabled control mode"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds NBFC configuration for **Acer Nitro ANV15-52** (Acer Nitro V 15, 2024 model).

## Verification

EC register layout verified via ACPI DSDT (`nbfc acpi-dump dsl`):

| Register | DSDT field | Purpose |
|----------|------------|---------|
| `0x49` (73) | `ERCT` (8-bit) | CPU fan write |
| `0x4A` (74) | byte after `ERCT` | GPU fan write |
| `0x5C` (92) | `CPUF` (16-bit) | CPU fan RPM read |
| `0x6A` (106) | `GPUF` (16-bit) | GPU fan RPM read |
| `0x58` (88) | `CTMP` | CPU temp |
| `0x59` (89) | `GTMP` | GPU temp |
| `0xBE` (190) | unnamed byte | Manual control enable |

EC register addresses match `Acer Nitro V15-41` config exactly (same product family).

## Test plan

- [x] Config applies via `nbfc config -a "Acer Nitro ANV15-52"`
- [x] Both fans report RPM via `nbfc status`
- [x] Fan speeds respond to CPU/GPU temperature changes
- [x] Verified with `dev_port` EC access method (Fedora 44, kernel 7.0.4 — `ec_sys`/`acpi_ec` modules unavailable)
- [x] Fan #1 uses `nvidia-ml` sensor for independent GPU temp tracking

## Notes

Thresholds tuned for aggressive cooling (0% until 35°C, 100% at 85°C). Based on `Acer Nitro V15-41.json` baseline.

System: `dmidecode -t system` reports Manufacturer: Acer, Product Name: Nitro ANV15-52.