### PR TITLE
Fix: nbfc_service systemd restart loop on laptops with hybrid graphics and dgpu turned off

### DIFF
--- a/etc/systemd/system/nbfc_service.service.in
+++ b/etc/systemd/system/nbfc_service.service.in
@@ -6,6 +6,7 @@ ExecStart=@BINDIR@/nbfc start
 ExecStop=@BINDIR@/nbfc stop
 Type=forking
 PIDFile=@RUNSTATEDIR@/nbfc_service.pid
+TimeoutStartSec=40
 TimeoutStopSec=20
 Restart=on-failure
 


### PR DESCRIPTION
Problem:
- laptop with hybrid graphics (intel igpu + nvidia dgpu)
- dgpu disabled (BIOS or software)
- systemd default start timeout <30s
- nbfc_service enters systemd restart loop because of 30s sleep time in FS_Sensors_Init() polling for the nvidia sensor

Fix:
- added 40s start timeout in systemd service file