### PR TITLE
fix(cli): clarify that CONFIG is a file name, not a model name

### DIFF
--- a/src/client/cmd_config.c
+++ b/src/client/cmd_config.c
@@ -146,6 +146,7 @@ int Set_Or_Apply(void) {
     ConfigFile* found = ConfigFiles_FindIgnoreCase(&files, config);
     if (! found) {
       Log_Error("No such configuration available: %s", config);
+      Log_Error("Use \"nbfc config --list\" to see available configuration file names");
       return NBFC_EXIT_FAILURE;
     }
 

--- a/src/help/client.help.h
+++ b/src/help/client.help.h
@@ -47,18 +47,25 @@
  ""
 
 #define CLIENT_CONFIG_HELP_TEXT                                                \
- "Usage: nbfc config [-h] (-l | -s config | -a config | -r)\n"                 \
+ "Usage: nbfc config [-h] (-l | -s CONFIG | -a CONFIG | -r)\n"                 \
  "\n"                                                                          \
  "Set or list configurations for the NBFC service.\n"                          \
  "\n"                                                                          \
  "Optional arguments:\n"                                                       \
  "  -h, --help            Show this help message and exit\n"                   \
- "  -l, --list            List all available configs\n"                        \
+ "  -l, --list            List all available configuration file names\n"       \
  "  -s CONFIG, --set CONFIG\n"                                                 \
- "                        Set a config\n"                                      \
+ "                        Set a configuration file as the selected config\n"     \
+ "                        (use --list to see available file names)\n"           \
  "  -a CONFIG, --apply CONFIG\n"                                               \
- "                        Set a config and start the service\n"                \
+ "                        Set a configuration file and start the service\n"      \
+ "                        (use --list to see available file names)\n"           \
  "  -r, --recommend       List configs with a similar notebook model name\n"   \
+ "\n"                                                                          \
+ "CONFIG is the configuration file name (without .json extension),\n"          \
+ "not the notebook model name.\n"                                              \
+ "For example, use \"Lenovo Thinkpad L540\" instead of \"Thinkpad L540\".\n"     \
+ "Use --list to see all available configuration file names.\n"                  \
  "\n"                                                                          \
  "If CONFIG is \"auto\", the service will attempt to automatically select\n"   \
  "a matching configuration.\n"                                                 \


### PR DESCRIPTION
## Summary

- Clarify that `nbfc config --set CONFIG` takes a **configuration file name** (e.g., `Lenovo Thinkpad L540`), not the notebook model name (e.g., `Thinkpad L540`)
- Improve `--list` output description
- Add a hint when the config is not found suggesting to use `--list`
- Add an example in the help text

This addresses the confusion reported in issue #239, where users tried `--set "Thinkpad L540"` when they should have used `--set "Lenovo Thinkpad L540"`.

## Changes

| File | Change |
|------|--------|
| `src/help/client.help.h` | Improved `CLIENT_CONFIG_HELP_TEXT` — clarify CONFIG means file name, add example |
| `src/client/cmd_config.c` | Added hint to use `--list` in the error message |

## Test Plan

- [x] `nbfc config --help` shows improved help text
- [x] `nbfc config --set nonexistent` shows helpful error message suggesting `--list`

Fixes #239
