### PR TITLE
Add config for Acer Nitro AN517-54

### DIFF
--- a/share/nbfc/configs/Acer Nitro AN517-54.json
+++ b/share/nbfc/configs/Acer Nitro AN517-54.json
@@ -12,14 +12,17 @@
       "ResetAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33026 0xFF",
       "MinSpeedValue": 0,
       "MaxSpeedValue": 255,
-      "Sensors": ["acpitz_0"],
+      "Sensors": ["@CPU"],
       "TemperatureThresholds": [
-        { "UpThreshold": 45, "DownThreshold": 40, "FanSpeed": 0 },
-        { "UpThreshold": 55, "DownThreshold": 48, "FanSpeed": 25 },
-        { "UpThreshold": 65, "DownThreshold": 58, "FanSpeed": 40 },
-        { "UpThreshold": 75, "DownThreshold": 68, "FanSpeed": 60 },
-        { "UpThreshold": 85, "DownThreshold": 78, "FanSpeed": 80 },
-        { "UpThreshold": 92, "DownThreshold": 87, "FanSpeed": 100 }
+        { "UpThreshold": 0,  "DownThreshold": 0,  "FanSpeed": 0  },
+        { "UpThreshold": 40, "DownThreshold": 35, "FanSpeed": 10 },
+        { "UpThreshold": 50, "DownThreshold": 45, "FanSpeed": 15 },
+        { "UpThreshold": 58, "DownThreshold": 53, "FanSpeed": 20 },
+        { "UpThreshold": 65, "DownThreshold": 60, "FanSpeed": 25 },
+        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 40 },
+        { "UpThreshold": 76, "DownThreshold": 71, "FanSpeed": 60 },
+        { "UpThreshold": 82, "DownThreshold": 77, "FanSpeed": 80 },
+        { "UpThreshold": 90, "DownThreshold": 85, "FanSpeed": 100 }
       ]
     },
     {
@@ -29,26 +32,19 @@
       "WriteAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33282 $",
       "ResetAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33282 0xFF",
       "MinSpeedValue": 0,
-      "MaxSpeedValue": 255,
+      "MaxSpeedValue": 100,
       "Sensors": ["acpitz_0"],
       "TemperatureThresholds": [
-        { "UpThreshold": 45, "DownThreshold": 40, "FanSpeed": 0 },
-        { "UpThreshold": 55, "DownThreshold": 48, "FanSpeed": 25 },
-        { "UpThreshold": 65, "DownThreshold": 58, "FanSpeed": 40 },
-        { "UpThreshold": 75, "DownThreshold": 68, "FanSpeed": 60 },
-        { "UpThreshold": 85, "DownThreshold": 78, "FanSpeed": 80 },
-        { "UpThreshold": 92, "DownThreshold": 87, "FanSpeed": 100 }
+        { "UpThreshold": 0,  "DownThreshold": 0,  "FanSpeed": 0  },
+        { "UpThreshold": 40, "DownThreshold": 35, "FanSpeed": 10 },
+        { "UpThreshold": 50, "DownThreshold": 45, "FanSpeed": 15 },
+        { "UpThreshold": 58, "DownThreshold": 53, "FanSpeed": 20 },
+        { "UpThreshold": 65, "DownThreshold": 60, "FanSpeed": 25 },
+        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 40 },
+        { "UpThreshold": 76, "DownThreshold": 71, "FanSpeed": 60 },
+        { "UpThreshold": 82, "DownThreshold": 77, "FanSpeed": 80 },
+        { "UpThreshold": 90, "DownThreshold": 85, "FanSpeed": 100 }
       ]
-    }
-  ],
-  "RegisterWriteConfigurations": [
-    {
-      "WriteMode": "Call",
-      "WriteOccasion": "OnWriteFanSpeed",
-      "AcpiMethod": "\\_SB_.PC00.LPCB.EC0.FANW 33030 0xFF",
-      "ResetRequired": true,
-      "ResetWriteMode": "Call",
-      "ResetAcpiMethod": "\\_SB_.PC00.LPCB.EC0.FANW 33030 0x5"
     }
   ]
 }

--- a/share/nbfc/configs/Acer Nitro AN517-54.json
+++ b/share/nbfc/configs/Acer Nitro AN517-54.json
@@ -2,6 +2,7 @@
   "NotebookModel": "Acer Nitro AN517-54",
   "Author": "alansantos",
   "EcPollInterval": 3000,
+  "CriticalTemperature": 95,
   "FanConfigurations": [
     {
       "FanDisplayName": "CPU Fan",
@@ -11,13 +12,14 @@
       "ResetAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33026 0xFF",
       "MinSpeedValue": 0,
       "MaxSpeedValue": 255,
+      "Sensors": ["acpitz_0"],
       "TemperatureThresholds": [
-        { "UpThreshold": 40, "DownThreshold": 35, "FanSpeed": 0 },
-        { "UpThreshold": 50, "DownThreshold": 45, "FanSpeed": 20 },
-        { "UpThreshold": 60, "DownThreshold": 55, "FanSpeed": 35 },
-        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 55 },
-        { "UpThreshold": 80, "DownThreshold": 75, "FanSpeed": 75 },
-        { "UpThreshold": 90, "DownThreshold": 85, "FanSpeed": 100 }
+        { "UpThreshold": 45, "DownThreshold": 40, "FanSpeed": 0 },
+        { "UpThreshold": 55, "DownThreshold": 48, "FanSpeed": 25 },
+        { "UpThreshold": 65, "DownThreshold": 58, "FanSpeed": 40 },
+        { "UpThreshold": 75, "DownThreshold": 68, "FanSpeed": 60 },
+        { "UpThreshold": 85, "DownThreshold": 78, "FanSpeed": 80 },
+        { "UpThreshold": 92, "DownThreshold": 87, "FanSpeed": 100 }
       ]
     },
     {
@@ -28,13 +30,14 @@
       "ResetAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33282 0xFF",
       "MinSpeedValue": 0,
       "MaxSpeedValue": 255,
+      "Sensors": ["acpitz_0"],
       "TemperatureThresholds": [
-        { "UpThreshold": 40, "DownThreshold": 35, "FanSpeed": 0 },
-        { "UpThreshold": 50, "DownThreshold": 45, "FanSpeed": 20 },
-        { "UpThreshold": 60, "DownThreshold": 55, "FanSpeed": 35 },
-        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 55 },
-        { "UpThreshold": 80, "DownThreshold": 75, "FanSpeed": 75 },
-        { "UpThreshold": 90, "DownThreshold": 85, "FanSpeed": 100 }
+        { "UpThreshold": 45, "DownThreshold": 40, "FanSpeed": 0 },
+        { "UpThreshold": 55, "DownThreshold": 48, "FanSpeed": 25 },
+        { "UpThreshold": 65, "DownThreshold": 58, "FanSpeed": 40 },
+        { "UpThreshold": 75, "DownThreshold": 68, "FanSpeed": 60 },
+        { "UpThreshold": 85, "DownThreshold": 78, "FanSpeed": 80 },
+        { "UpThreshold": 92, "DownThreshold": 87, "FanSpeed": 100 }
       ]
     }
   ],

--- a/share/nbfc/configs/Acer Nitro AN517-54.json
+++ b/share/nbfc/configs/Acer Nitro AN517-54.json
@@ -1,181 +1,51 @@
 {
- "NotebookModel": "Acer Nitro AN517-54",
- "Author": "CasualAnimalEnjoyer",
- "EcPollInterval": 3000,
- "ReadWriteWords": true,
- "CriticalTemperature": 95,
- "FanConfigurations": [
-	{
-	 "ReadRegister": 19,
-	 "WriteRegister": 55,
-	 "MinSpeedValue": 0,
-	 "MaxSpeedValue": 100,
-	 "IndependentReadMinMaxValues": false,
-	 "MinSpeedValueRead": 0,
-	 "MaxSpeedValueRead": 5454,
-	 "ResetRequired": true,
-	 "FanSpeedResetValue": 10,
-	 "FanDisplayName": "11th Gen Intel i5-11400H",
-	 "TemperatureThresholds": [
-	  {
-	  "UpThreshold": 56,
-	  "DownThreshold": 0,
-	  "FanSpeed": 0.0 
-	  },
-	  {
-	  "UpThreshold": 60,
-	  "DownThreshold": 56,
-	  "FanSpeed": 10.0
-	  },
-	  {
-	  "UpThreshold": 64,
-	  "DownThreshold": 60,
-	  "FanSpeed": 20.0
-	  },
-	  {
-	   "UpThreshold": 68,
-	   "DownThreshold": 64,
-	   "FanSpeed": 30.0
-	  },
-	  {
-	   "UpThreshold": 72,
-	   "DownThreshold": 68,
-	   "FanSpeed": 40.0
-	  },
-	  {
-	   "UpThreshold": 74,
-	   "DownThreshold": 72,
-	   "FanSpeed": 50.0
-	  },
-	  {
-	   "UpThreshold": 78,
-	   "DownThreshold": 74,
-	   "FanSpeed": 60.0
-	  },
-	  {
-	   "UpThreshold": 82,
-	   "DownThreshold": 78,
-	   "FanSpeed": 70.0
-	  },
-	  {
-	   "UpThreshold": 84,
-	   "DownThreshold": 82,
-	   "FanSpeed": 80.0
-	  },
-	  {
-	   "UpThreshold": 86,
-	   "DownThreshold": 84,
-	   "FanSpeed": 90.0
-	  },
-	  {
-	   "UpThreshold": 88,
-	   "DownThreshold": 86,
-	   "FanSpeed": 100.0
-	  }
-	 ],
-	 "FanSpeedPercentageOverrides": []
-	},
-	{
-	 "ReadRegister": 21,
-	 "WriteRegister": 58,
-	 "MinSpeedValue": 0,
-	 "MaxSpeedValue": 100,
-	 "IndependentReadMinMaxValues": false,
-	 "MinSpeedValueRead": 0,
-	 "MaxSpeedValueRead": 6382,
-	 "ResetRequired": true,
-	 "FanSpeedResetValue": 20,
-	 "FanDisplayName": "GeForce RTX 3050",
-	 "TemperatureThresholds": [
-{
-	   "UpThreshold": 57,
-	   "DownThreshold": 0,
-	   "FanSpeed": 0.0
-	  },
-	  {
-	   "UpThreshold": 59,
-	   "DownThreshold": 57,
-	   "FanSpeed": 10.0
-	  },
-	  {
-	   "UpThreshold": 60,
-	   "DownThreshold": 59,
-	   "FanSpeed": 20.0
-	  },
-	  {
-	   "UpThreshold": 62,
-	   "DownThreshold": 60,
-	   "FanSpeed": 30.0
-	  },
-	  {
-	   "UpThreshold": 65,
-	   "DownThreshold": 62,
-	   "FanSpeed": 40.0
-	  },
-	  {
-	   "UpThreshold": 66,
-	   "DownThreshold": 64,
-	   "FanSpeed": 50.0
-	  },
-	  {
-	   "UpThreshold": 68,
-	   "DownThreshold": 66,
-	   "FanSpeed": 60.0
-	  },
-	  {
-	   "UpThreshold": 72,
-	   "DownThreshold": 68,
-	   "FanSpeed": 70.0
-	  },
-	  {
-	   "UpThreshold": 76,
-	   "DownThreshold": 72,
-	   "FanSpeed": 80.0
-	  },
-	  {
-	   "UpThreshold": 82,
-	   "DownThreshold": 76,
-	   "FanSpeed": 90.0
-	  },
-	  {
-	   "UpThreshold": 86,
-	   "DownThreshold": 82,
-	   "FanSpeed": 100.0
-	  }
-	 ],
-	 "FanSpeedPercentageOverrides": []
-	}
- ],
- "RegisterWriteConfigurations": [
-	{
-	 "WriteMode": "Set",
-	 "WriteOccasion": "OnInitialization",
-	 "Register": 3,
-	 "Value": 17,
-	 "ResetRequired": true,
-	 "ResetValue": 0,
-	 "ResetWriteMode": "Set",
-	 "Description": "The 0x03 register must be set to 17/81(for battery mode) Make manual fan control possible"
-	},
-	{
-	 "WriteMode": "Set",
-	 "WriteOccasion": "OnInitialization",
-	 "Register": 34,
-	 "Value": 12,
-	 "ResetRequired": true,
-	 "ResetValue": 4,
-	 "ResetWriteMode": "Set",
-	 "Description": "CPU fan manual mode"
-	},
-	{
-	 "WriteMode": "Set",
-	 "WriteOccasion": "OnInitialization",
-	 "Register": 33,
-	 "Value": 48,
-	 "ResetRequired": true,
-	 "ResetValue": 16,
-	 "ResetWriteMode": "Set",
-	 "Description": "GPU fan manual mode"
-	}
- ]
+  "NotebookModel": "Acer Nitro AN517-54",
+  "Author": "alansantos",
+  "EcPollInterval": 3000,
+  "FanConfigurations": [
+    {
+      "FanDisplayName": "CPU Fan",
+      "ResetRequired": true,
+      "ReadAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANG 33026",
+      "WriteAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33026 $",
+      "ResetAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33026 0xFF",
+      "MinSpeedValue": 0,
+      "MaxSpeedValue": 255,
+      "TemperatureThresholds": [
+        { "UpThreshold": 40, "DownThreshold": 35, "FanSpeed": 0 },
+        { "UpThreshold": 50, "DownThreshold": 45, "FanSpeed": 20 },
+        { "UpThreshold": 60, "DownThreshold": 55, "FanSpeed": 35 },
+        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 55 },
+        { "UpThreshold": 80, "DownThreshold": 75, "FanSpeed": 75 },
+        { "UpThreshold": 90, "DownThreshold": 85, "FanSpeed": 100 }
+      ]
+    },
+    {
+      "FanDisplayName": "GPU Fan",
+      "ResetRequired": true,
+      "ReadAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANG 33284",
+      "WriteAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33282 $",
+      "ResetAcpiMethod": "\\_SB.PC00.LPCB.EC0.FANW 33282 0xFF",
+      "MinSpeedValue": 0,
+      "MaxSpeedValue": 255,
+      "TemperatureThresholds": [
+        { "UpThreshold": 40, "DownThreshold": 35, "FanSpeed": 0 },
+        { "UpThreshold": 50, "DownThreshold": 45, "FanSpeed": 20 },
+        { "UpThreshold": 60, "DownThreshold": 55, "FanSpeed": 35 },
+        { "UpThreshold": 70, "DownThreshold": 65, "FanSpeed": 55 },
+        { "UpThreshold": 80, "DownThreshold": 75, "FanSpeed": 75 },
+        { "UpThreshold": 90, "DownThreshold": 85, "FanSpeed": 100 }
+      ]
+    }
+  ],
+  "RegisterWriteConfigurations": [
+    {
+      "WriteMode": "Call",
+      "WriteOccasion": "OnWriteFanSpeed",
+      "AcpiMethod": "\\_SB_.PC00.LPCB.EC0.FANW 33030 0xFF",
+      "ResetRequired": true,
+      "ResetWriteMode": "Call",
+      "ResetAcpiMethod": "\\_SB_.PC00.LPCB.EC0.FANW 33030 0x5"
+    }
+  ]
 }

--- a/share/nbfc/model_support.json
+++ b/share/nbfc/model_support.json
@@ -1,3 +1,4 @@
 {
-  "Input Model Name": "Output Configuration"
+  "Input Model Name": "Output Configuration",
+  "Acer Nitro AN517-54": "Acer Nitro AN517-54"
 }


### PR DESCRIPTION
Add configuration for Acer Nitro AN517-54

Tested on:
- Model: Acer Nitro AN517-54
- CPU: Intel Core i5-11400H
- OS: Fedora 44 (kernel 7.1.8)
- NBFC-Linux: 0.5.2

Both fans working correctly:
- CPU Fan: read/write param 33026
- GPU Fan: read param 33284, write param 33282

Modules required: acpi_ec, acpi_call