### PR TITLE
Increase hardcoded sensors limit in fs_sensors.c

### DIFF
--- a/src/fs_sensors.c
+++ b/src/fs_sensors.c
@@ -78,7 +78,7 @@ static Error FS_Sensors_Init_HwMon(void) {
   array_size_t n_sources = 0;
 
   for (const char* const* hwmonDir = LinuxHwmonDirs; *hwmonDir; ++hwmonDir) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 20; i++) {
       snprintf(dir,  PATH_MAX, *hwmonDir, i);
       snprintf(file, PATH_MAX, "%s/name", dir);
 


### PR DESCRIPTION
**Problem**
---
The hardcoded limit for number of sensors is 10 but `coretemp` sensor may show up at values higher 10.

```
INFO: nbfc_service: NBFC-Linux comes with no warranty. Run `nbfc warranty` for details.
INFO: nbfc_service: Running version 0.4.1
INFO: nbfc_service: SYSCONFDIR is "/etc"
INFO: nbfc_service: DATADIR is "/usr/share"
INFO: nbfc_service: RUNSTATEDIR is "/run"
INFO: nbfc_service: Available Embedded Controllers: ec_sys, acpi_ec, dev_port, dummy
INFO: nbfc_service: Using "HP ZBook 15 G3" as model config
INFO: nbfc_service: Waiting for nvidia sensor ...
...
INFO: nbfc_service: Waiting for nvidia sensor ...
INFO: nbfc_service: Available temperature source: "acpitz_0" (/sys/class/hwmon/hwmon1/temp1_input)
INFO: nbfc_service: Available temperature source: "acpitz_1" (/sys/class/hwmon/hwmon2/temp1_input)
INFO: nbfc_service: Available temperature source: "acpitz_2" (/sys/class/hwmon/hwmon3/temp1_input)
INFO: nbfc_service: Available temperature source: "acpitz_3" (/sys/class/hwmon/hwmon4/temp1_input)
INFO: nbfc_service: Available temperature source: "acpitz_4" (/sys/class/hwmon/hwmon5/temp1_input)
INFO: nbfc_service: Available temperature source: "acpitz_5" (/sys/class/hwmon/hwmon6/temp1_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp1_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp2_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp3_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp4_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp5_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp6_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp7_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp8_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon8/temp9_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon9/temp1_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon9/temp2_input)
INFO: nbfc_service: Available temperature source: "nvme" (/sys/class/hwmon/hwmon9/temp3_input)
INFO: nbfc_service: Available temperature source: "pch_skylake_6" (/sys/class/hwmon/hwmon10/temp1_input)
INFO: nbfc_service: Available temperature source: "coretemp" (/sys/class/hwmon/hwmon12/temp1_input)
INFO: nbfc_service: Available temperature source: "coretemp" (/sys/class/hwmon/hwmon12/temp2_input)
INFO: nbfc_service: Available temperature source: "coretemp" (/sys/class/hwmon/hwmon12/temp3_input)
INFO: nbfc_service: Available temperature source: "coretemp" (/sys/class/hwmon/hwmon12/temp4_input)
INFO: nbfc_service: Available temperature source: "coretemp" (/sys/class/hwmon/hwmon12/temp5_input)
INFO: nbfc_service: Available temperature source: "iwlwifi_1_8" (/sys/class/hwmon/hwmon13/temp1_input)
INFO: nbfc_service: Using "ec_sys" as EmbeddedControllerType
INFO: nbfc_service: Fan #0 (Left CPU fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp1_input) as temperature source (Average)
INFO: nbfc_service: Fan #0 (Left CPU fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp2_input) as temperature source (Average)
INFO: nbfc_service: Fan #0 (Left CPU fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp3_input) as temperature source (Average)
INFO: nbfc_service: Fan #0 (Left CPU fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp4_input) as temperature source (Average)
INFO: nbfc_service: Fan #0 (Left CPU fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp5_input) as temperature source (Average)
INFO: nbfc_service: Fan #1 (Right CPU Fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp1_input) as temperature source (Average)
INFO: nbfc_service: Fan #1 (Right CPU Fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp2_input) as temperature source (Average)
INFO: nbfc_service: Fan #1 (Right CPU Fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp3_input) as temperature source (Average)
INFO: nbfc_service: Fan #1 (Right CPU Fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp4_input) as temperature source (Average)
INFO: nbfc_service: Fan #1 (Right CPU Fan) uses "coretemp" (/sys/class/hwmon/hwmon12/temp5_input) as temperature source (Average)
```