### PR TITLE
Add configuration for HP ZBook 15 G4

### DIFF
--- a/share/nbfc/configs/HP ZBook 15 G4.json
+++ b/share/nbfc/configs/HP ZBook 15 G4.json
@@ -1,0 +1,118 @@
+{
+ "LegacyTemperatureThresholdsBehaviour": true,
+ "NotebookModel": "HP ZBook 15 G4",
+ "Author": "Dom O'Brien",
+ "EcPollInterval": 1000,
+ "ReadWriteWords": false,
+ "CriticalTemperature": 85,
+ "FanConfigurations": [
+  {
+   "FanDisplayName": "CPU Fan",
+   "ReadRegister": 46,
+   "WriteRegister": 47,
+   "MinSpeedValue": 170,
+   "MaxSpeedValue": 50,
+   "IndependentReadMinMaxValues": true,
+   "MinSpeedValueRead": 175,
+   "MaxSpeedValueRead": 45,
+   "ResetRequired": true,
+   "FanSpeedResetValue": 255,
+   "TemperatureThresholds": [
+    {
+     "UpThreshold": 0,
+     "DownThreshold": 0,
+     "FanSpeed": 0.0
+    },
+    {
+     "UpThreshold": 50,
+     "DownThreshold": 45,
+     "FanSpeed": 20.0
+    },
+    {
+     "UpThreshold": 57,
+     "DownThreshold": 52,
+     "FanSpeed": 30.0
+    },
+    {
+     "UpThreshold": 63,
+     "DownThreshold": 58,
+     "FanSpeed": 40.0
+    },
+    {
+     "UpThreshold": 68,
+     "DownThreshold": 63,
+     "FanSpeed": 55.0
+    },
+    {
+     "UpThreshold": 73,
+     "DownThreshold": 68,
+     "FanSpeed": 70.0
+    },
+    {
+     "UpThreshold": 77,
+     "DownThreshold": 72,
+     "FanSpeed": 85.0
+    },
+    {
+     "UpThreshold": 80,
+     "DownThreshold": 75,
+     "FanSpeed": 100.0
+    }
+   ]
+  },
+  {
+   "FanDisplayName": "GPU Fan",
+   "ReadRegister": 53,
+   "WriteRegister": 54,
+   "MinSpeedValue": 170,
+   "MaxSpeedValue": 50,
+   "IndependentReadMinMaxValues": true,
+   "MinSpeedValueRead": 175,
+   "MaxSpeedValueRead": 45,
+   "ResetRequired": true,
+   "FanSpeedResetValue": 255,
+   "TemperatureThresholds": [
+    {
+     "UpThreshold": 0,
+     "DownThreshold": 0,
+     "FanSpeed": 0.0
+    },
+    {
+     "UpThreshold": 50,
+     "DownThreshold": 45,
+     "FanSpeed": 20.0
+    },
+    {
+     "UpThreshold": 57,
+     "DownThreshold": 52,
+     "FanSpeed": 30.0
+    },
+    {
+     "UpThreshold": 63,
+     "DownThreshold": 58,
+     "FanSpeed": 40.0
+    },
+    {
+     "UpThreshold": 68,
+     "DownThreshold": 63,
+     "FanSpeed": 55.0
+    },
+    {
+     "UpThreshold": 73,
+     "DownThreshold": 68,
+     "FanSpeed": 70.0
+    },
+    {
+     "UpThreshold": 77,
+     "DownThreshold": 72,
+     "FanSpeed": 85.0
+    },
+    {
+     "UpThreshold": 80,
+     "DownThreshold": 75,
+     "FanSpeed": 100.0
+    }
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Adds a configuration for the **HP ZBook 15 G4** (Kaby Lake mobile workstation, dual fan, Quadro M1200).

Tested on LMDE 7 (Debian 13 trixie), kernel 6.12.101, nbfc-linux 0.5.3, `ec_sys` backend.

## Register identification

Rather than adapting the existing `HP ZBook 15 G3` config on the strength of the model name, the registers were identified two independent ways and cross-checked.

**Statistically**, by logging all 256 EC registers once per second through an idle → load → cooldown cycle and correlating each against true fan RPM from the `hp_wmi_sensors` hwmon driver. `0x2e` correlated at −1.00 with RPM and `0x2f` at −0.96 (negative because HP's scale is inverted: lower byte = faster fan).

**From firmware**, via `nbfc acpi-dump ec-registers`, which gave HP's own field names and confirmed the inference exactly:

| Register | DSDT name | Meaning |
|---:|---|---|
| `0x2d` | `AFAN` | Auto fan control flag |
| `0x2e` | `FRDC` | Fan Read Duty Cycle |
| `0x2f` | `FTGC` | Fan TarGet duty Cycle |
| `0x35` | `FR2C` | Fan 2 read duty cycle |
| `0x36` | `FT2C` | Fan 2 target duty cycle |

The register layout is unchanged from the ZBook 15 G3 and the EliteBook 850 G5, but the speed values differ, so the config is not interchangeable with either.

## Calibration

Each value was written to `FTGC`/`FT2C` and the resulting speed read from `hp_wmi_sensors`. Rows marked ✓ were held 40–45 s to full steady state; the remainder come from a faster sweep (7 s per step) and slightly understate RPM because the EC ramps the fan gradually toward its target.

| Value | CPU Fan | GPU Fan | |
|---:|---:|---:|:--|
| 255 | *BIOS control* | *BIOS control* | ✓ |
| 210–170 | 0 | 0 | ✓ |
| 164 | 0 | 1508 | ✓ |
| 150 | 1638 | 1638 | ✓ |
| 140 | 1743 | 1743 | |
| 130 | 1905 | 1905 | |
| 120 | 2065 | 2065 | |
| 110 | 2234 | 2234 | |
| 100 | 2458 | 2458 | ✓ |
| 90 | 2587 | 2560 | |
| 80 | 2926 | 2926 | |
| 70 | 3321 | 3321 | |
| 60 | 4096 | 4096 | ✓ |
| 50 | 4312 | 4165 | |
| < 50 | no further increase | | |

Three things this determined:

- **The two fans have different stop points.** The CPU fan stops at 164, but the GPU fan still turns at 1508 RPM there and only stops at 170. `MinSpeedValue` is 170 for both so that 0% genuinely means both fans off.
- **`MaxSpeedValue` is 50, not the G3's 60.** At 60 the fans reach 4096 RPM; at 50 they reach 4312. Below 50 there is no further gain.
- **`FanSpeedResetValue` 255 hands control back to the firmware.** Writing 255 causes the EC to resume its own curve within a second or two, confirmed by watching `FRDC` return to a BIOS-chosen value.

## No `RegisterWriteConfigurations`

The ZBook 15 G3 and EliteBook 850 G5 configs both pin the thermal zone (`CRZN`, `0x22`) and write a fake 28 °C into `TEMP` (`0x26`) to stop the firmware overriding fan writes. That is not necessary here, and this config omits it.

Verified by writing a slow fan value and holding it under full load: `FTGC` stayed at the written value for 141 consecutive seconds while the CPU climbed from 42 °C to 91 °C. The EC never intervened.

Since the spoofing trick works precisely by blinding the EC to real temperature, omitting it keeps the firmware's own view of the system intact at no cost.

**A warning for anyone using this hardware:** that same test shows the EC will *not* force the fans up on this machine. It watched the CPU reach 91 °C with the fans at 1640 RPM and did nothing. There is no firmware safety net below the CPU package's own thermal throttling. `CriticalTemperature` is therefore set to 85 °C and the curve reaches 100% at 80 °C — those are the only protection this configuration has, and they should not be relaxed without understanding that.

## Curve

Balanced: silent at idle, ramping from 50 °C, full speed by 80 °C.

| Temp | Speed | Register | Approx RPM |
|---:|---:|---:|---:|
| 0 °C | 0% | 170 | 0 (fans off) |
| 50 °C | 20% | 146 | ~1700 |
| 57 °C | 30% | 134 | ~1900 |
| 63 °C | 40% | 122 | ~2065 |
| 68 °C | 55% | 104 | ~2400 |
| 73 °C | 70% | 86 | ~2900 |
| 77 °C | 85% | 68 | ~3300 |
| 80 °C | 100% | 50 | ~4300 |

The lowest active step is 20% rather than 10% deliberately: at 10% the register value lands at 158, which is inside the CPU fan's dead zone, so the first step of the curve would have moved no air at all.

`LegacyTemperatureThresholdsBehaviour` is set to `true`, matching the other HP configs in the tree. Without it the `{Up: 0, Down: 0, FanSpeed: 0}` entry is unreachable — the service parks on the 20% step and never descends to 0% — which defeats the main purpose of the config.

## Results

**Idle**, both measured after 15 minutes settled at the same ambient:

| | CPU Fan | GPU Fan | CPU temp |
|---|---:|---:|---:|
| Firmware control | 2119 RPM | 0 | 40 °C |
| This config | **0 RPM** | 0 | 39 °C |

The firmware holds the CPU fan at ~2119 RPM indefinitely at idle. This is with *Fan Always on while on AC Power* already disabled in the BIOS — that setting stops the GPU fan but does not affect the CPU fan's floor.

**Under load** (`stress-ng --cpu 8`, 3 minutes): 78 °C at 3668 RPM, against 81 °C under firmware control. A real but modest improvement — beyond roughly 3000 RPM this cooler gives diminishing returns. The substantive gain from this config is silence at idle, not load temperatures.

**Shutdown**: `nbfc stop` returns the fans to firmware control cleanly.

## Note for anyone deploying this

Because the EC does not intervene (see above), if `nbfc_service` is terminated
ungracefully the fans remain at whatever value it last wrote — verified with
`SIGKILL`, after which both fans stayed at 0 RPM. A clean `nbfc stop` restores
firmware control correctly; only ungraceful termination is affected.

This is service behaviour rather than anything specific to this config, but on
hardware with no firmware fan fallback it is worth guarding. A systemd drop-in
handles it, since `ExecStopPost` runs even when the main process is killed:

```ini
[Service]
ExecStopPost=-/usr/bin/ec_probe write 47 255
ExecStopPost=-/usr/bin/ec_probe write 54 255
Restart=on-failure
```

## Read range

`IndependentReadMinMaxValues` is `true`, with a read range of 175–45 against a
write range of 170–50.

The duty readback (`FRDC`/`FR2C`) does not exactly mirror the written value: it
settles within about ±2 of it. Writing 170 for 0% reads back as 171 or 172, and
writing 164 read back as 163. With the read bounds inherited from the write
values, every poll at 0% therefore failed the range check and the service logged
a warning every couple of seconds. The declared read range carries ±5 of
headroom to absorb that jitter.

The consequence is that the reported *current* speed is approximate — 0% reads
as ~4% and 100% as ~96% — while control, which uses the write range, is exact.

One warning still appears once at startup:

```
WARNING: GPU Fan: Fan speed value (255) not range of MinSpeedValueRead/MaxSpeedValueRead
```

`255` is a sentinel the GPU fan reports while the firmware owns it and the fan is
stopped, rather than a duty value. It is read once before the service takes
control and does not recur.
